### PR TITLE
faqs.md: Add reference to schedv2.py

### DIFF
--- a/faqs.md
+++ b/faqs.md
@@ -271,7 +271,7 @@ Anki’s algorithm differs from SM-2 in some respects. Notably:
     the card to get stuck in "low interval hell". In Anki, the initial
     acquisition process does not influence a card’s ease.
 
-You can also check out 'sched.py' in Anki’s source code for the
+You can also check out `sched.py` and `schedv2.py` in Anki’s source code for the
 scheduling code. Here is a summary (see the [deck options](deck-options.md)
 section for the options that are mentioned in 'italics').
 


### PR DESCRIPTION
I don't know if the text description incorporates any changes in the v2 scheduler or that must be added, but it might be good to at least reference scheduler version 2, as that is the default being used in new versions.