### PR TITLE
directly link to the specific section

### DIFF
--- a/studying.md
+++ b/studying.md
@@ -309,4 +309,4 @@ creating a [filtered deck](filtered-decks.md).
 When you answer cards that have been waiting for a while, Anki factors
 in that delay when determining the next time a card should be shown.
 Please see the section on Anki’s spaced-repetition
-[algorithm](faqs.md) for more information.
+[algorithm](https://faqs.ankiweb.net/due-times-after-a-break.html) for more information.


### PR DESCRIPTION
Linking to FAQs is not very helpful, and it took me some searches to find out the specific section it is referring to. 

As FAQs are moved to another repo recently in June, I assume the link will not change for a while. So I think we should directly link to the section using URL.

I'm not familiar with docify, please edit my file if the syntax is wrong. I guess the markdown syntax works.