### PR TITLE
Overwrite negative left margin for kbd tags

### DIFF
--- a/browsing.md
+++ b/browsing.md
@@ -25,7 +25,7 @@ cards from either of the decks in the same view.
 You can hold down <kbd>Alt</kbd> (<kbd>Option</kbd> on Mac) in order to reverse the
 search (prepend a `-`) – for instance, to show all cards in a current deck that
 do *not* have a certain tag. <kbd>Alt</kbd>/<kbd>Option</kbd> can be combined with
-either <kbd>Ctrl</kbd> or <kbd>Shift</kbd> (e.g., <kbd>Ctrl</kbd>-<kbd>Alt</kbd>-clicking
+either <kbd>Ctrl</kbd> or <kbd>Shift</kbd> (e.g., <kbd>Ctrl</kbd>+<kbd>Alt</kbd>-clicking
 will result in adding a new search term that is negated).
 
 On Anki 2.1.39+, you can also hold down both <kbd>Ctrl</kbd> and

--- a/index.html
+++ b/index.html
@@ -22,6 +22,14 @@
       :root {
         --sidebar-nav-pagelink-background-image--loaded: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='7' height='11.2' viewBox='0 0 7 11.2'%3E%3Cpath d='M1.5 1.5l4 4.1 -4 4.1' stroke-width='1.5' stroke='rgb%28179, 179, 179%29' fill='none' stroke-linecap='square' stroke-linejoin='miter' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E");
       }
+
+      /* overwrite negative left margin from themeable */
+      .markdown-section kbd {
+        margin: 0.15em;
+      }
+      .markdown-section kbd + kbd {
+        margin: 0.15em;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
I just fixed the overlapping issue. The styling is ugly but even if I could do it better it would need to be adjusted with every theme change.
[This](https://github.com/jhildenbiddle/docsify-themeable/blob/7008137b8079bc267e66e653dedb18d8e417f605/src/scss/app/_content.scss#L260) is the line causing the issue. Maybe they'll fix it and we can revert this commit in the future.