### PR TITLE
New scheduler updates filtered decks, relearning, buried cards

### DIFF
--- a/filtered-decks.md
+++ b/filtered-decks.md
@@ -111,11 +111,13 @@ such as limiting to tags, finding cards forgotten a certain number of
 times, and so on. Please see the [searching](searching.md) section of the
 manual for more information on the different possibilities.
 
-Filtered decks can not pull in cards that are suspended, buried, or
-already in a different filtered deck. And unless you are using the
-experimental scheduler, they can not pull in cards that are in
-(re)learning. For this reason, a search in the browser may reveal cards
-that don’t end up in the filtered deck.
+With the old scheduler, filtered decks cannot pull in cards that are
+suspended, buried, or already in a different filtered deck, whereas in the 
+[new scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html)
+cards *can* be buried or suspended while remaining in the filtered deck. 
+Again, unless you are using the new scheduler, filtered decks also can not
+pull in cards that are in (re)learning. For this reason, a search in the browser
+may reveal cards that don’t end up in the filtered deck.
 
 The **limit** option controls how many cards will be gathered into the
 deck. The order you select controls both the order cards are gathered

--- a/filtered-decks.md
+++ b/filtered-decks.md
@@ -82,12 +82,13 @@ It is also possible to move all cards back to their home decks at once:
     also removes the emptied deck from the deck list. No cards are
     deleted when you delete a filtered deck.
 
-In the current implementation, if you create, rebuild, empty or delete a
+In the old scheduler, if you create, rebuild, empty or delete a
 filtered deck while cards are still in learning, they will be turned
 back into new cards. In the case of failed reviews in relearning, any
 remaining relearning steps will be skipped. This has been fixed in the
-[experimental
-scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html).
+[new
+scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html) so cards
+are no longer reset.
 
 ## Creating Manually
 
@@ -181,9 +182,11 @@ Cards return to their home deck when (re)learning is complete. Thus if
 you have 3 learning steps, a new card will return to its home deck upon
 three presses of "Good" or a single press of "Easy".
 
-The **custom steps** option allows you to override the home deck’s steps
-and provide your own steps instead. The provided steps apply to both
-cards being learnt, lapsed reviews, and reviews ahead of time.
+In the old scheduler, the **custom steps** option allows you to override the 
+home deck’s steps and provide your own steps instead. The provided steps apply to both
+cards being learnt, lapsed reviews, and reviews ahead of time. Please note, however, that
+in the [new scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html)
+filtered decks no longer support custom steps.
 
 ## Counts
 
@@ -241,9 +244,9 @@ delay.
 ## Rescheduling
 
 By default, Anki will return cards to their home decks with altered
-scheduling based on your performance in the filtered deck. If you
-disable the **reschedule cards based on my answers** option, Anki will
-return the cards in the same state they were in when they were moved
+scheduling based on your performance in the filtered deck. In the old
+scheduler, if you disable the **reschedule cards based on my answers** option,
+Anki will return the cards in the same state they were in when they were moved
 into the filtered deck. This is useful for quickly flipping through
 material.
 
@@ -253,6 +256,11 @@ return to its home deck with its original scheduling.
 
 Please note that new cards are returned to the end of the new card
 queue, rather than the start of it.
+
+In the [new scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html), 
+there is no longer an option to disable scheduling changes. Instead, you will
+have access to a simple "preview mode". The new card order does not get forgotten
+when previewing.
 
 ## Catching Up
 

--- a/preferences.md
+++ b/preferences.md
@@ -66,7 +66,7 @@ Controls when Anki should start showing the next day’s cards. The default
 setting of 4AM ensures that if you’re studying around midnight, you won’t have
 two days' worth of cards shown to you in one session. If you stay up very late
 or wake up very early, you may want to adjust this to a time you’re usually
-sleeping.
+sleeping. Note that the start of the next day is relative to your current timezone. 
 
 **Learn ahead limit**  
 Tells Anki how to behave when there is nothing left to study in the current deck

--- a/searching.md
+++ b/searching.md
@@ -222,6 +222,10 @@ cards that have been manually suspended
 cards that have been buried, either [automatically](studying.md#siblings-and-burying) or
 manually
 
+Note that with the [new scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html),
+Anki now distinguishes between manually and automatically buried cards so you can
+unbury one set without the other.
+
 Cards that have lapsed fall into several of these categories, so it may
 be useful to combine them to get more precise results:
 

--- a/studying.md
+++ b/studying.md
@@ -91,9 +91,10 @@ card will be shown again the next day, then at increasingly long delays
 
 **Easy** immediately converts the card into a review card, even if there
 were steps remaining. By default, the card will be shown again 4 days
-later, and then at increasingly long delays. The easy button will not be
+later, and then at increasingly long delays. In the old scheduler, the "Easy" button will not be
 shown if you are in relearning mode and it would give the same interval
-as “good.”
+as “Good.” With the [new scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html),
+when cards are in relearning, the "Easy" button boosts the interval by 1 day.
 
 When cards are seen for the first time, they start at step one. This
 means answering **Good** on a card for the first time will show it one


### PR DESCRIPTION
This updates the manual to include some of the remaining changes from [the 2.1 scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html) release, most notably information about filtered decks. 

This is part of the work for open issue: [update manual to reflect changes in 2.1 scheduler #1073](https://github.com/ankitects/anki/issues/1073)