### PR TITLE
Fix addon-docs links and anchors

### DIFF
--- a/src/contrib.md
+++ b/src/contrib.md
@@ -56,7 +56,7 @@ them about it.
 
 ## Sharing Add-ons
 
-Please see <https://addon-docs.ankiweb.net/#/sharing>
+Please see <https://addon-docs.ankiweb.net/sharing.html>
 
 ## Translating Anki
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -14,13 +14,13 @@ translations may not always be up to date.
 - [Español](https://apps.ankiweb.net/docs/manual.es.html)
 - [Français](https://apps.ankiweb.net/docs/manual.fr.html)
 - [Italiano](https://web.archive.org/web/20160423223801/http://192.167.9.6/Anki_ITA/Manual_ITA.htm)
-- [Polski](https://platynowy.github.io/anki-manual/#/)
+- [Polski](https://platynowy.github.io/anki-manual/)
 - [Português Brasileiro](https://mizerablebr.github.io/anki-manual/)
-- [русский язык](https://alexeygorelov.github.io/anki-manual-ru/#/)
+- [русский язык](https://alexeygorelov.github.io/anki-manual-ru/)
 - [العربية](https://abdnh.github.io/anki-manual/)
 - [فارسى](http://ankidroid.ir/anki.pdf)
 - [日本語](http://wikiwiki.jp/rage2050/?FrontPage)
 - [简体中文](http://www.ankichina.net/manual/anki/)
 
 If you would like to help translate the manual into a different language,
-please see the [translation docs](https://translating.ankiweb.net/#/anki/manual).
+please see the [translation docs](https://translating.ankiweb.net/anki/manual.html).

--- a/src/misc.md
+++ b/src/misc.md
@@ -17,7 +17,7 @@ for more information.
 Sometimes you may be asked to use the debug console to change a setting
 or check something. Unless asked to enter text in the "debug console",
 you will probably not need this. Advanced users may like to read more
-about it in the [add-on writing guide](https://addon-docs.ankiweb.net/#/more?id=debugging).
+about it in the [add-on writing guide](https://addon-docs.ankiweb.net/features-and-debugging.html#debugging).
 
 When asked to enter text into the "debug console", please start Anki,
 and in the main window, press

--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -95,7 +95,7 @@ img#star {
 
 You can explore the styling of cards interactively by using Chrome:
 
-<https://ankitects.github.io/addon-docs/#/porting2.0?id=webview-changes>
+<https://addon-docs.ankiweb.net/porting2.0.html#webview-changes>
 
 ## Field Styling
 
@@ -225,7 +225,7 @@ web if you’d like to learn more.
 
 If your card templates are complex, it may be difficult to read the
 question and answer columns (called "Front" and "Back") in the [card
-list](../browsing.md#card-list). The "browser appearance" option allows you to define a
+list](../browsing.md#cardnote-table). The "browser appearance" option allows you to define a
 custom template to be used only in the browser, so you can include only
 the important fields and change the order if you desire. The syntax is
 the same as in standard card templates.


### PR DESCRIPTION
In theory, all links should be valid with this. 🙂