### PR TITLE
Add a section about text direction

### DIFF
--- a/src/editing.md
+++ b/src/editing.md
@@ -145,7 +145,7 @@ Only one field can be the sort field at once.
 display text from right to left (RTL), such as Arabic or Hebrew. This
 setting currently only controls editing; to make sure the text displays
 correctly during review, you'll need to adjust your
-[template](templates/styling.md).
+[template](templates/styling.md#text-direction).
 
 After you have added fields, you will probably want to add them to the front
 or back of your cards. For more information on that, please see the

--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -208,6 +208,24 @@ make them smaller and colored, you could use the following:
 }
 ```
 
+## Text Direction
+
+If you use a language that is written right-to-left, such as Arabic or Hebrew,
+you can add the CSS `direction` property to the .card section for correct display during review:
+```css
+.card {
+  direction: rtl;
+}
+```
+
+This will change the direction of the entire card. You can change the direction
+of only certain fields by wrapping their references in some HTML:
+
+    <div dir="rtl">{{Front}}</div>
+
+To change the direction of fields in the editor, please see
+the [editing](../editing.md#customizing-fields) section.
+
 ## Other HTML
 
 Your templates can contain arbitrary HTML, which means that all the


### PR DESCRIPTION
This adds a section explaining how to change text direction in card templates (common question among users using RTL languages).