### PR TITLE
Update Contrib File Name

### DIFF
--- a/src/contrib.md
+++ b/src/contrib.md
@@ -70,5 +70,5 @@ Please see <https://translating.ankiweb.net>
 
 Anki's source code is available at <https://github.com/ankitects/anki>
 
-Before contributing, please see the README.contributing file in that
+Before contributing, please see the contributing.md file in that
 repo.

--- a/src/contrib.md
+++ b/src/contrib.md
@@ -70,5 +70,4 @@ Please see <https://translating.ankiweb.net>
 
 Anki's source code is available at <https://github.com/ankitects/anki>
 
-Before contributing, please see the contributing.md file in that
-repo.
+Before contributing, please see [contributing.md](https://github.com/ankitects/anki/blob/main/docs/contributing.md).


### PR DESCRIPTION
On[ the contributing page of the manual](https://docs.ankiweb.net/contrib.html) it says:
> Before contributing, please see the README.contributing file in that repo.

However, it appears that this file has just been renamed to `contributing.md`.

This PR just corrects the file name, which should make it easier for potential contributors to get started.