### PR TITLE
Add instructions for searching for &, >, and <

### DIFF
--- a/src/searching.md
+++ b/src/searching.md
@@ -374,6 +374,12 @@ you need to tell Anki not to treat them specially.
   So `w:e:b` is a word boundary search for `e:b`, `w\:e\:b` searches literally for
   `w:e:b` and `w\:e:b` searches the field `w:e` for `b` (see
   [field searches](#limiting-to-a-field)).
+  
+- `&`, `<`, and `>`  
+  `&`, `<`, and `>` are treated as HTML when searching in Anki, and as such searches
+  containing them don't work as expected. However, you can search for them by using their
+  corresponding HTML entity names (`&amp;` for `&`, `&lt;` for `<`, and `&gt;` for `>`).
+  For example, searching `&lt;&amp;text&gt;` searches for a card with `<&text>` in a field.
 
 ### Raw input
 


### PR DESCRIPTION
I noticed that there isn't a way to search for the `&`, `>`, and `<` characters in Anki. Quoting or using `re:` on them doesn't work, and using a backslash to escape them gives you an invalid search error. But I found that using the HTML entity names works to search for cards containing them, so it's probably useful to put in the manual for anyone else in the future who comes across the issue.