### PR TITLE
Update manual to state it only sync on full sync

### DIFF
--- a/src/files.md
+++ b/src/files.md
@@ -166,7 +166,7 @@ correctly.
 ## Backups
 
 Each time your collection is closed (when closing Anki, switching
-profiles, or synchronizing your deck), Anki exports your collection into
+profiles, or doing a full deck synchronization), Anki exports your collection into
 the backups folder. By default Anki will store up to 30 backups; you can
 adjust this in the [preferences](preferences.md).
 


### PR DESCRIPTION
I used to press sync to do backup before trying some change that may break my collection. I just discovered that I broke my collection and have no fork of the last 4 hours of reviews.
This update would not have helped me as I would not have read it, but at least new reader have up to date information