### PR TITLE
Warn about format changes interpreted as word boundaries

### DIFF
--- a/src/searching.md
+++ b/src/searching.md
@@ -50,7 +50,9 @@ etc.
 
 `w:dog`  
 search for "dog" on a word boundary - will match "dog", but not "doggy"
-or "underdog". Requires Anki 2.1.24+ or AnkiMobile 2.1.61+.
+or "underdog". Requires Anki 2.1.24+ or AnkiMobile 2.1.61+. Note that
+formatting changes may be interpreted as word boundaries e.g. searching 
+for `w:exam` will match **exam**ple. 
 
 `w:dog*`  
 will match "dog" and "doggy", but not "underdog".


### PR DESCRIPTION
See here for how the current behaviour when using `w:` can cause unexpected matches:
https://forums.ankiweb.net/t/incorrect-browser-search-results/19156/4