### PR TITLE
Fix conditional tts for ankidroid

### DIFF
--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -137,7 +137,7 @@ Then in the styling section:
 .android .ankitts {
   display: none;
 }
-:not(.android) .ankidroidtts {
+html:not(.android) .ankidroidtts {
   display: none;
 }
 ```


### PR DESCRIPTION
Selector `:not(.android) .ankidroidtts`, will hide the content even if it is ankidroid, because of the way `:not()` works. Refer [JSFiddle](https://jsfiddle.net/0faxheou/)

It is best to specify the parent tag (`html`) on which class `android` is specified.