### PR TITLE
math.md: Typo and minor fixes

### DIFF
--- a/src/math.md
+++ b/src/math.md
@@ -25,7 +25,7 @@ To try it out:
 
         \(\sqrt{x}\)
 
-4.  If you click the Cards…​ button, you’ll see a preview of how the
+4.  If you click the Cards… button, you’ll see a preview of how the
     equation will appear when the card is reviewed.
 
 Anki’s MathJax support expects content in TeX format. If you’re not
@@ -70,8 +70,8 @@ LaTeX forum.
 To install LaTeX, on Windows use MiKTeX; on macOS use MacTex, and on Linux
 use your distro’s package manager. Dvipng must also be installed.
 
-On Windows, go to Settings in MikTek’s maintenance window, and make sure
-"Install missing packages on the fly" is set to "No", not to "Ask me
+On Windows, go to Settings in MikTeX’s maintenance window, and make sure
+"Install missing packages on the fly" is set to "Always", not to "Ask me
 first". If you continue to have difficulties, one user reported that
 running Anki as an administrator until all the packages were fetched
 helped.


### PR DESCRIPTION
I think there's an issue [here](https://github.com/ankitects/anki-manual/blob/bd853086b19dd7cf1a32018d7ee7912cd9737d58/src/math.md?plain=1#L74). If "Install missing packages on the fly" is set to "No", MikTex will not automatically fetch and install missing packages when Anki wants to render a document with new packages, causing a fatal error raised by MikTex. If it is set to "Always", everything works well. The problem is also mentioned in the [LaTeX Stack Exchange Community](https://tex.stackexchange.com/a/471185).