### PR TITLE
Add argument to use unzstd to uncompress

### DIFF
--- a/src/platform/linux/installing.md
+++ b/src/platform/linux/installing.md
@@ -32,7 +32,7 @@ To install Anki:
 3. Open a terminal and run the following commands, replacing the filename as appropriate.
 
 ```shell
-tar xaf Downloads/anki-2.1.XX-linux-qt6.tar.zst
+tar xaf --use-compress-program=unzstd Downloads/anki-2.1.XX-linux-qt6.tar.zst
 cd anki-2.1.XX-linux-qt6
 sudo ./install.sh
 ```


### PR DESCRIPTION
Add argument to use unzstd to uncompress the installation folder. Without `--use-compress-program=unzstd` it would fail on my machine.