### PR TITLE
Added {{CardFlag}} to fields.md

### DIFF
--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -154,6 +154,8 @@ There are some special fields you can include in your templates:
 
     The card's subdeck: {{Subdeck}}
 
+    The card's flag: {{CardFlag}}
+
     The type of card ("Forward", etc): {{Card}}
 
     The content of the front template


### PR DESCRIPTION
It seems like `{{CardFlag}}` was missing from the documentation, so I quickly added it in.

P.S. Would you be against adding the `{{furigana:...}` / `{{kana:...}}` / `{{kanji:...}}` to the documentation? I remember initially thinking that these required an addon to work, but it turns out it's supported natively by Anki. If not, I can make another PR to add it in.