### PR TITLE
document TTS platform discrepancy and fix

### DIFF
--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -125,21 +125,34 @@ using the `cloze-only` filter, like so:
 The cloze-only filter is supported in Anki 2.1.29+ and AnkiMobile 2.0.65+.
 
 You can enable Anki's TTS feature on supported platforms while falling back to [AnkiDroid's
-own method](https://docs.ankidroid.org/#_workarounds) by placing something like this in your templates:
+own method](https://docs.ankidroid.org/#_workarounds). Until AnkiDroid 
+supports the {{tts:FieldName}} syntax, it will render these fields as 
+text, while other platforms will render a (re)play audio button. In order 
+to temporarily fix this discrepancy between platforms, we can use the 
+following in our templates:
 
 ```html
-<span class="ankidroidtts"><tts service="android" voice="en_US">{{Front}}</tts></span><span class="ankitts">{{tts en_US:Front}}</span>
+<tts service="android" voice="en_US">{{Front}}</tts>
+
+<span class="ankitts">Anki tts:{{tts en_US:Front}}</span>
+
+<button class="ankidroidTtsButton" onclick="
+AnkiDroidJS.ankiTtsSpeak('{{Front}}');">Play TTS</button>
 ```
 
 Then in the styling section:
 
 ```css
+/*Anki (desktop) TTS needs to be hidden because AnkiDroid currently renders it as text instead of a play button like desktop.*/
 .android .ankitts {
   display: none;
 }
-html:not(.android) .ankidroidtts {
+
+/*The AnkiDroid tts button won't work on other platforms because it uses the JS API, therefore it should be hidden*/
+html:not(.android) .ankidroidTtsButton { 
   display: none;
-}
+} 
+
 ```
 
 ## Special Fields

--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -134,7 +134,7 @@ following in our templates:
 ```html
 <tts service="android" voice="en_US">{{Front}}</tts>
 
-<span class="ankitts">Anki tts:{{tts en_US:Front}}</span>
+<span class="ankitts">{{tts en_US:Front}}</span>
 
 <button class="ankidroidTtsButton" onclick="
 AnkiDroidJS.ankiTtsSpeak('{{Front}}');">Play TTS</button>


### PR DESCRIPTION
AnkiDroid renders {{tts FieldName}} as text while other platforms render a (re)play TTS button. We should hide this text if we're on Android. To give AnkiDroid users a (re)play TTS button, we can make one that calls the JS API, and hide this button for all other platforms.

Ironically, I had to copy and paste this on mobile, so there may be mistakes.

Edit: a small thing to note is that this code renders text in the {{Front}} field on the platforms I tested (AnkiDroid and desktop (Linux). The occurency of {{Front}} which is responsible for this is the one surrounded by AnkiDroid's `<tts>` tags. If this text is undesirable, it also be hidden using CSS. I just wasn't sure if I should include that as well since it would result in front template that was visually blank.