### PR TITLE
Clarifying AnkiDroid Self-Hosted Sync Server Endpoint Requirements

### DIFF
--- a/src/sync-server.md
+++ b/src/sync-server.md
@@ -119,8 +119,8 @@ toggle "Allow Anki to access local network" off and then on again.
 
 Older desktop clients required you to define SYNC_ENDPOINT and SYNC_ENDPOINT_MEDIA.
 If using an older client, you'd put it as e.g. `http://192.168.1.200:8080/sync/`
-and `http://192.168.1.200:8080/msync/` respectively. AnkiDroid also currently
-requires separate configuration for the two endpoints.
+and `http://192.168.1.200:8080/msync/` respectively. AnkiDroid clients before 2.16
+require separate configuration for the two endpoints.
 
 ## Reverse Proxies
 


### PR DESCRIPTION
This is to address:

https://forums.ankiweb.net/t/expand-clarify-ankidroid-self-sync-server-docs/32678

The change to AnkiDroid is discussed here:

ankidroid/Anki-Android#13056