### PR TITLE
Add sentence about {{type:Field}} on ankiweb.net

### DIFF
--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -440,3 +440,5 @@ the text box with a comma.
 
 Type answer boxes will not appear in the ["preview" dialog](intro.md) in the browser. When you review or look at
 the preview in the card types window, they will display.
+
+Type answer boxes will not be displayed, when you review your cards on [ankiweb.net](../syncing.md).

--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -441,4 +441,4 @@ the text box with a comma.
 Type answer boxes will not appear in the ["preview" dialog](intro.md) in the browser. When you review or look at
 the preview in the card types window, they will display.
 
-Type answer boxes will not be displayed, when you review your cards on [ankiweb.net](../syncing.md).
+Type answer boxes will not be displayed when you review your cards on [ankiweb.net](../syncing.md).


### PR DESCRIPTION
The commit adds a sentence which mentions that type boxes will not be displayed on ankiweb.net.

I didn't add a description about how one might work around this (for e.g. by creating filtered decks, which collect all the typ-in-the-answer cards), because the section is already pretty long. I could however add this if it seems useful.