### PR TITLE
unified one more instance of the spelling of AnkiWeb

### DIFF
--- a/src/contrib.md
+++ b/src/contrib.md
@@ -19,7 +19,7 @@ location as before. If you shared a deck when it was called "Korean
 Verbs" for example, and then renamed it to "Korean::Korean Verbs",
 resharing will not be able to update the existing copy. If you have
 forgotten the original name, you can guess it by downloading the
-deck on ankiweb and importing it (File > Import) in a new profile
+deck on AnkiWeb and importing it (File > Import) in a new profile
 (File > Switch profile > Add). Then you can copy the exact name of the
 deck when it was first shared. If this doesn't work, please contact
 support.


### PR DESCRIPTION
Last time I searched for all Ankiweb instances and corrected them to AnkiWeb but there was one ankiweb ->AnkiWeb instance missing in the manual