### PR TITLE
Add a Dependabot config to keep GitHub action versions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
The `actions/checkout` action was recently updated to version 4.

Rather than submit a PR to update it once, this PR introduces a Dependabot config that will keep all GitHub actions updated on a regular basis.

If this PR merges, you can expect Dependabot to immediately submit at least one PR to update `actions/checkout@v3` to `v4`.