### PR TITLE
Add link to last Win32 Release (#1076)

### DIFF
--- a/src/platform/windows/installing.md
+++ b/src/platform/windows/installing.md
@@ -8,7 +8,7 @@ Recent Anki releases require a computer running the 64 bit version of Windows
 10 or 11.
 
 - The last Anki release that supported Windows 7 and 8.1 was Anki 2.1.49.
-- The last Anki release that supported 32 bit Windows was Anki 2.1.35-alternate.
+- The last Anki release that supported 32 bit Windows was [Anki 2.1.35-alternate](https://github.com/ankitects/anki/releases/tag/2.1.35).
 
 If you're on an old machine, you can obtain old releases from the [releases page](https://github.com/ankitects/anki/releases).
 


### PR DESCRIPTION
I added a direct link to the last release that supports Win 32 OS. As someone with a Win32 system that uses Anki (who has reinstalled on more than one occasion), knowing exactly where to find the most-updated release would be helpful.

