### PR TITLE
Add and reword links to installation/startup issues

### DIFF
--- a/src/platform/windows/installing.md
+++ b/src/platform/windows/installing.md
@@ -65,4 +65,6 @@ you can download older Anki versions from the [releases page](https://github.com
 ## Problems
 
 If you encounter any issues when installing or starting Anki, please see the
-following links on the left.
+following pages:
+- [Installation Issues](https://docs.ankiweb.net/platform/windows/installation-issues.html)
+- [Startup Issues](https://docs.ankiweb.net/platform/windows/startup-issues.html)


### PR DESCRIPTION
For reasons similar to https://github.com/ankitects/anki-manual/pull/160, added a link to installation issues and startup issues page for either mobile users (who would not see the links to the left, if at all), or users who have (intentionally or otherwise) closed their table of contents.