### PR TITLE
Add and reword links to install inssues

### DIFF
--- a/src/platform/linux/installing.md
+++ b/src/platform/linux/installing.md
@@ -81,4 +81,12 @@ you can download older Anki versions from the [releases page](https://github.com
 ## Problems
 
 If you encounter any issues when installing or starting Anki, please see the
-following links on the left.
+following pages:
+- [Missing Libraries](https://docs.ankiweb.net/platform/linux/missing-libraries.html)
+- [Display Issues](https://docs.ankiweb.net/platform/linux/display-issues.html)
+- [Blank Main Window](https://docs.ankiweb.net/platform/linux/blank-window.html)
+- [Linux Distro Packages](https://docs.ankiweb.net/platform/linux/distro-packages.html)
+- [Incorrect GTK Theme](https://docs.ankiweb.net/platform/linux/gtk-theme.html)
+- [Wayland](https://docs.ankiweb.net/platform/linux/wayland.html)
+- [Input Methods](https://docs.ankiweb.net/platform/linux/input-methods.html)
+


### PR DESCRIPTION
Added a link to various installtion issues pages, similar to https://github.com/ankitects/anki-manual/pull/161 and https://github.com/ankitects/anki-manual/pull/160, for consistency (and ease of use for mobile users who may not see the menu).