### PR TITLE
add link to v2 scheduler

### DIFF
--- a/src/studying.md
+++ b/src/studying.md
@@ -148,7 +148,7 @@ cards in that queue, not the number of _cards_. If you have multiple
 steps configured for lapsed cards, the number will increase by more than
 one when you fail a card, since that card needs to be shown several times.
 
-From the v2 scheduler, the numbers count _cards_, so the number will always
+From the [v2 scheduler](https://faqs.ankiweb.net/the-anki-2.1-scheduler.html), the numbers count _cards_, so the number will always
 increase by one regardless of the steps remaining.
 
 When the answer is shown, Anki shows an estimate of the next time a card


### PR DESCRIPTION
added a link to v2 scheduler for users who don't know what it is (also the first mention of it in the manual if you're reading in order)