### PR TITLE
Minor semantic correction

### DIFF
--- a/src/templates/intro.md
+++ b/src/templates/intro.md
@@ -40,7 +40,7 @@ options to rename or reorder the cards, as well as the following two
 options:
 
 - The 'Deck Override' option allows you to change the deck that cards
-  generated from the current card type will be placed into. By
+  generated from the current note type will be placed into. By
   default, cards are placed into the deck you provide in the Add Notes
   window. If you set a deck here, that card type will be placed into
   the deck you specified, instead of the deck listed in the Add Notes


### PR DESCRIPTION
I assume 'note type' was meant: 'Cards from the current note type' can be placed in separately specified decks with the help of 'Deck Override' option