### PR TITLE
Improve sentence clarity and fix typos

### DIFF
--- a/src/deck-options.md
+++ b/src/deck-options.md
@@ -392,7 +392,7 @@ The options are:
 Requires Anki 23.12 or later. Auto Advance allows you to automatically reveal
 the answer and/or move to the next card. To use it, you must first set a non-zero
 time in "seconds to show question" and/or "seconds to show answer". Then, in the
-review screen, use the Auto Advance action from the More button to start advancing.
+review screen, use the Auto Advance action from the `More` button to start advancing.
 
 ## Burying
 
@@ -516,7 +516,7 @@ If you have less than 1,000 reviews, you can use the default parameters that
 are already entered into the "FSRS parameters" field. Even with the default
 parameters, FSRS should work well for most users.
 
-Once you've done 1000+ reviews in Anki, you can use the Optimize button to
+Once you've done 1000+ reviews in Anki, you can use the `Optimize` button to
 analyze your review history, and automatically generate parameters that are
 optimal for your memory and the content you're studying. Parameters are
 preset-specific, so if you have decks that vary wildly in difficulty, it
@@ -531,7 +531,7 @@ are used for optimizing the parameters.
 
 **Evaluate FSRS parameters**
 
-You can use the Evaluate button in the "Optimize FSRS parameters"
+You can use the `Evaluate` button in the "Optimize FSRS parameters"
 section to see metrics that show how well the parameters in the
 "Model parameters" field fit your review history. Smaller numbers
 indicate a better fit to your review history.
@@ -559,15 +559,16 @@ desired retention field.
 
 #### Learning and Re-learning Steps
 
-(Re)learning steps of 1+ days are not recommended when using FSRS. The main
-reason they were popular with the old SM-2 scheduler is because repeatedly
-failing a card after learning could reduce its ease a lot, leading to what
-some people called "ease hell". This is not a problem that FSRS suffers from.
-By keeping your learning steps under a day, you will allow FSRS to schedule
-cards at times it has calculated are optimum for your material and memory.
-Another reason not to use longer learning steps is because FSRS may end up
-scheduling the first review for a shorter time than your last learning step,
-leading to the Hard button showing a longer time than Good.
+(Re)learning steps of 1+ days are not recommended when using FSRS. The main 
+reason they were popular with the old SM-2 scheduler is because repeatedly 
+failing a card after it has graduated from the learning phase could reduce 
+its ease a lot, leading to what some people called "ease hell". This is not 
+a problem that FSRS suffers from.  By keeping your learning steps under a 
+day, you will allow FSRS to schedule cards at times it has calculated are 
+optimum for your material and memory.  Another reason not to use longer 
+learning steps is because FSRS may end up scheduling the first review for a 
+shorter time than your last learning step, leading to the `Hard` button 
+showing a longer time than `Good`.
 
 We also recommend you keep the number of learning steps to a minimum. Evidence
 shows that repeating a card multiple times in a single day after you've

--- a/src/deck-options.md
+++ b/src/deck-options.md
@@ -359,7 +359,7 @@ Controls how review cards are sorted while reviewing. The options are:
   you have a large backlog that may take some time to get through, and you want to
   reduce the chances of forgetting more cards.
 
-  When using the SM-2 scheduler, overduessness is determined by comparing how
+  When using the SM-2 scheduler, overdueness is determined by comparing how
   overdue cards are, and how long their interval is. For example, a card with a
   current interval of 5 days that is overdue by 2 days, will display before a card
   with a current interval of 10 days that is overdue by 3 days.


### PR DESCRIPTION
Hello,


First, happy new year!

I went over the [new additions](https://github.com/ankitects/anki-manual/compare/1db23cd..f15752f#diff-13dce136e586859a8a3aae45c092bfc1588848d145719f6f8f37931bc5000131) since the 1db23cd70d61c20096bb74ae240e4d063c344a1d.

Not much has come up other than this small typo and sentence.

I have added the markdown grave accents around the buttons.

There are few more questions, if you do not mind:
1. "[Log-loss](https://github.com/ankitects/anki-manual/blob/main/src/deck-options.md?plain=1#L539)" in the official manual: what is this referring to exactly? Review log? Or [_Log_ arithm](https://en.wikipedia.org/wiki/Logarithm)? I have translated it as "Review log", but now I am thinking that it might be referring to _Log_ arithm.
2. This question is related to the [following line](https://github.com/ankitects/anki/blob/3982e0c8fe691d3e84deceb7555f2d2fd0a8fbe6/ftl/core/preferences.ftl#L26) in Anki. This is the only British "Synchroni **s** ation" in Anki. All of the others are American. I wanted to open a PR, but I thought it may not be worth it (hence why I asked first).

As always, many thank for all of your hard work last year.


HR