### PR TITLE
removed random -- and bug with next page

### DIFF
--- a/src/preferences.md
+++ b/src/preferences.md
@@ -175,5 +175,3 @@ For info on the custom sync server option, see [this section](./sync-server.md).
 ## Backups
 
 Please see [this](backups.md#automatic-backups) section of the manual.
-
----


### PR DESCRIPTION
Reported on Discord by mod khonkhortisan


Next chapter > links back to the same page for these pages: Installing & Upgrading Anki on [Windows](https://docs.ankiweb.net/platform/windows/installing.html) [macOS](https://docs.ankiweb.net/platform/mac/installing.html) [Linux](https://docs.ankiweb.net/platform/linux/installing.html)

[Preferences](https://docs.ankiweb.net/preferences.html) has a hr at the bottom

About the Next chapter issue, seems like Docs can't recognize 2.1.x, and it returns the main page, Windows 2.1

Runs perfectly here: https://doc.rust-lang.org/nightly/reference/expressions.html

Part of the code that handles Previous/Next (unsure on how to implement here)
https://github.com/rust-lang/mdBook/blob/5a4ac03c0de866c4cf30d41dd0c7ea02d8429a7a/guide/src/format/theme/index-hbs.md?plain=1#L80