### PR TITLE
Added missing links to Windows problem pages

### DIFF
--- a/src/platform/windows/installing.md
+++ b/src/platform/windows/installing.md
@@ -69,6 +69,4 @@ following pages:
 - [Installation Issues](https://docs.ankiweb.net/platform/windows/installation-issues.html)
 - [Startup Issues](https://docs.ankiweb.net/platform/windows/startup-issues.html)
 - [Display Issues](https://docs.ankiweb.net/platform/windows/display-issues.html)
-- [Copy and Paste Issues](https://docs.ankiweb.net/platform/windows/copy-and-paste.html)
-- [Text Size](https://docs.ankiweb.net/platform/windows/text-size.html)
 - [Permission Problems](https://docs.ankiweb.net/platform/windows/permission-problems.html)

--- a/src/platform/windows/installing.md
+++ b/src/platform/windows/installing.md
@@ -68,3 +68,7 @@ If you encounter any issues when installing or starting Anki, please see the
 following pages:
 - [Installation Issues](https://docs.ankiweb.net/platform/windows/installation-issues.html)
 - [Startup Issues](https://docs.ankiweb.net/platform/windows/startup-issues.html)
+- [Display Issues](https://docs.ankiweb.net/platform/windows/display-issues.html)
+- [Copy and Paste Issues](https://docs.ankiweb.net/platform/windows/copy-and-paste.html)
+- [Text Size](https://docs.ankiweb.net/platform/windows/text-size.html)
+- [Permission Problems](https://docs.ankiweb.net/platform/windows/permission-problems.html)


### PR DESCRIPTION
The Windows Install and Upgrade page is missing some links to problem pages in the relevant subsection.