### PR TITLE
Importing without scheduling data removes leech and marked tags

### DIFF
--- a/src/importing/packaged-decks.md
+++ b/src/importing/packaged-decks.md
@@ -15,7 +15,9 @@ or review history.
 If you encounter imported cards with unexpectedly large intevals, the deck author may
 accidentally have included their scheduling information. You can use the
 [Set Due Date feature](../browsing.md#cards) to reset the imported cards. On Anki
-23.10 and later, you can remove any scheduling information during the import process.
+23.10 and later, you can remove any scheduling information during the import process
+by leaving the "Import any learning progress" option unselected. This will also remove
+any "leech" or "marked" tags from the imported cards.
 
 ## Updating
 


### PR DESCRIPTION
Adding a note to the importing section to indicate that importing without scheduling data also removes "leech" and "marked" tags from the imported notes.