### PR TITLE
Learn color: orange → red

### DIFF
--- a/src/studying.md
+++ b/src/studying.md
@@ -137,7 +137,7 @@ to learn more about how the algorithm works.
 
 When only the question is shown, Anki shows three numbers like 6 + 9 + 59
 at the bottom of the screen. These represent the new cards (blue), cards in
-learning (orange), and cards to review (green). If you’d prefer not to see the numbers,
+learning (red), and cards to review (green). If you’d prefer not to see the numbers,
 you can turn them off in Anki’s [preferences.](preferences.md)
 
 ![Due Counts](media/due_counts.png)


### PR DESCRIPTION
I've never seen the "Learn" color referred to as "orange" anywhere else. From what I can tell, it is --  

- Light theme #dc2626
![image](https://github.com/user-attachments/assets/b23dcb9a-de36-4156-8236-0b05c84d3b08)
- Dark theme #f87171 [same as color for red flag]
![image](https://github.com/user-attachments/assets/9870a206-6c1a-464f-980c-f0c43e6f631e)

-- both of which are firmly in the "red" section of the only color palette I could find in the code.

[This definitely fell under the heading of faster to remind myself how to fix, than to post an issue about!]



