### PR TITLE
Replace the source of zh-CN translation

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -25,7 +25,7 @@ translations may not always be up to date.
 - [العربية](https://abdnh.github.io/anki-manual/)
 - [فارسى](http://ankidroid.ir/anki.pdf)
 - [日本語](http://wikiwiki.jp/rage2050/)
-- [简体中文](http://www.ankichina.net/manual/anki/)
+- [简体中文](https://open-spaced-repetition.github.io/anki-manual-zh-CN/)
 
 If you would like to help translate the manual into a different language,
 please see the [translation docs](https://translating.ankiweb.net/anki/manual.html).


### PR DESCRIPTION
The previous zh-CN translation is outdated and nobody maintains it. I make a new translation project and it has been deployed here: https://open-spaced-repetition.github.io/anki-manual-zh-CN/