### PR TITLE
fix getting-started link on platform/intro

### DIFF
--- a/src/platform/intro.md
+++ b/src/platform/intro.md
@@ -6,4 +6,4 @@ This section explains the way Anki is installed, and the possible problems you m
 - [macOS](./mac/intro.md)
 - [Linux](./linux/intro.md)
 
-If you have already installed Anki, you can skip to the [Getting Started](/getting-started.md) section.
+If you have already installed Anki, you can skip to the [Getting Started](../getting-started.md) section.


### PR DESCRIPTION
When building anki-manual locally, you receive the following warning:
```
warning: Absolute link should be made relative
  ┌─ platform/intro.md:9:57
  │
9 │ If you have already installed Anki, you can skip to the [Getting Started](/getting-started.md) section.
  │                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Absolute link should be made relative
  │
  = When viewing a document directly from the file system and click on an
    absolute link (e.g. `/index.md`), the browser will try to navigate to
    `/index.md` on the current file system (i.e. the `index.md` file inside
    `/` or `C:\`) instead of the `index.md` file at book's base directory as
    intended.

    This warning helps avoid the situation where everything will seem to work
    fine when viewed using a web server (e.g. GitHub Pages or `mdbook serve`),
    but users viewing the book from the file system may encounter broken links.

    To ignore this warning, you can edit `book.toml` and set the warning policy to
    "ignore".

        [output.linkcheck]
        warning-policy = "ignore"

    For more details, see https://github.com/Michael-F-Bryan/mdbook-linkcheck/issues/33
  = Suggestion: change the link to "../getting-started.md"
```

I just went and modified the problem link to fix that warning.

Let me know if there are any problems/questions 👍