### PR TITLE
Move custom scheduling info from FAQ

### DIFF
--- a/src/deck-options.md
+++ b/src/deck-options.md
@@ -643,4 +643,38 @@ that preserving part of the delay can actually [be counter-productive](https://s
 
 ### Custom Scheduling
 
-Please see [this page](https://faqs.ankiweb.net/the-2021-scheduler.html#add-ons-and-custom-scheduling).
+You can have more control over Anki's scheduling of cards by using your own JavaScript in the custom scheduling field. This is a global option, so code entered here applies to every preset.
+
+Here is an example custom scheduling script. Note that, for Qt5 versions of Anki, the code needs to be transpiled.
+
+```javascript
+// print the existing states
+console.log(
+  JSON.stringify(states, null, 4)
+);
+
+// load the debugger if the web inspector is open
+debugger;
+
+// if the hard button is a learning step, make it
+// a 123 minute delay
+if (states.hard.normal?.learning) {
+  states.hard.normal.learning.scheduledSecs = 123 * 60;
+}
+
+// apply the same change in a rescheduling filtered deck
+if (states.hard.filtered?.rescheduling?.originalState?.learning) {
+  states.hard.filtered.rescheduling.originalState.learning.scheduledSecs =
+    123 * 60;
+}
+
+// increase ease factor by 0.2 when Easy used on a review
+if (states.good.normal?.review) {
+  states.easy.normal.review.easeFactor =
+    states.good.normal.review.easeFactor + 0.2;
+}
+```
+
+You can also see [FSRS custom scheduling code](https://github.com/open-spaced-repetition/fsrs4anki/blob/main/fsrs4anki_scheduler.js) as an example.
+
+The various scheduling states of cards are described in [SchedulingStates](https://github.com/ankitects/anki/blob/main/proto/anki/scheduler.proto).


### PR DESCRIPTION
Used info from the FAQ page to write about custom scheduling in the main manual.

Also, linked to FSRS's custom scheduling code as another example.