### PR TITLE
Update video driver section from troubleshooting and their linked pages

### DIFF
--- a/src/platform/linux/display-issues.md
+++ b/src/platform/linux/display-issues.md
@@ -3,12 +3,12 @@
 Hardware acceleration defaults to on. If you experience blank screens
 or display issues, you can try enabling software rendering.
 
-### Changing the Driver from the Preferences Screen
+### Changing the Driver From the Preferences Screen
 In Anki 23.10+, you can change the graphics driver from preferences screen by
 navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.
 
-### Changing the Driver from the Terminal
+### Changing the Driver From the Terminal
 ```
 echo software > ~/.local/share/Anki2/gldriver6
 ```

--- a/src/platform/linux/display-issues.md
+++ b/src/platform/linux/display-issues.md
@@ -5,7 +5,7 @@ or display issues, you can try enabling software rendering.
 
 ### Using the Preferences Screen
 In Anki 23.10+, you can change the graphics driver from preferences screen by
-navigating to *Tools > Preferences* and then selecting the driver from the
+navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.
 
 ### Using the Terminal

--- a/src/platform/linux/display-issues.md
+++ b/src/platform/linux/display-issues.md
@@ -1,13 +1,17 @@
 ## Display Issues on Linux
 
 Hardware acceleration defaults to on. If you experience blank screens
-or display issues, you can try enabling software rendering using the terminal:
+or display issues, you can try enabling software rendering.
 
+### Using the Preferences Screen
+In Anki 23.10+, you can change the graphics driver from preferences screen by
+navigating to *Tools > Preferences* and then selecting the driver from the
+dropdown menu.
+
+### Using the Terminal
 ```
 echo software > ~/.local/share/Anki2/gldriver6
 ```
 
 If you wish to switch back to the default, change `software` to `auto`, or
 remove that file.
-
-In Anki 23.10+, you can also change the graphics driver from preferences screen.

--- a/src/platform/linux/display-issues.md
+++ b/src/platform/linux/display-issues.md
@@ -3,12 +3,12 @@
 Hardware acceleration defaults to on. If you experience blank screens
 or display issues, you can try enabling software rendering.
 
-### Changing the driver from the Preferences Screen
+### Changing the Driver from the Preferences Screen
 In Anki 23.10+, you can change the graphics driver from preferences screen by
 navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.
 
-### Changing the driver from the Terminal
+### Changing the Driver from the Terminal
 ```
 echo software > ~/.local/share/Anki2/gldriver6
 ```

--- a/src/platform/linux/display-issues.md
+++ b/src/platform/linux/display-issues.md
@@ -3,12 +3,12 @@
 Hardware acceleration defaults to on. If you experience blank screens
 or display issues, you can try enabling software rendering.
 
-### Using the Preferences Screen
+### Changing the driver from the Preferences Screen
 In Anki 23.10+, you can change the graphics driver from preferences screen by
 navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.
 
-### Using the Terminal
+### Changing the driver from the Terminal
 ```
 echo software > ~/.local/share/Anki2/gldriver6
 ```

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -2,7 +2,7 @@
 
 <!-- toc -->
 
-## Changing Video Drivers
+## Change the Video Driver
 
 ### From Preferences Screen
 If you're experiencing display issues or crashes in Anki 23.10+, you can try

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -2,7 +2,7 @@
 
 <!-- toc -->
 
-## Qt6 Video Driver
+## Video Driver
 
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
 changing the video driver in the preferences screen, then restarting Anki.

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -4,13 +4,13 @@
 
 ## Change the Video Driver
 
-### Changing the driver from the Preferences Screen
+### Changing the Driver from the Preferences Screen
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
 changing the video driver in the preferences screen by navigating to **Anki →
 Preferences** and then selecting the driver from the dropdown menu. After that it
 is necessary to restart Anki.
 
-### Changing the driver from Terminal.app
+### Changing the Driver from Terminal.app
 Older Anki versions did not provide an option in the preferences, but allowed
 you to adjust the driver by opening Terminal.app, then pasting the following and hit enter:
 
@@ -27,6 +27,6 @@ remove that file.
 
 If you experience blank screens when using an external graphics card on a Mac, you can ctrl+click on the Anki app, click "Get Info", and enable the "prefer eGPU" option.
 
-## Monitors with different resolutions
+## Monitors with Different Resolutions
 
 Please see [this forum post](https://forums.ankiweb.net/t/mac-known-issues-wording-suggestion/7331).

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -4,13 +4,13 @@
 
 ## Change the Video Driver
 
-### From Preferences Screen
+### Changing the driver from the Preferences Screen
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
 changing the video driver in the preferences screen by navigating to **Anki →
 Preferences** and then selecting the driver from the dropdown menu. After that it
 is necessary to restart Anki.
 
-### From Terminal.app
+### Changing the driver from Terminal.app
 Older Anki versions did not provide an option in the preferences, but allowed
 you to adjust the driver by opening Terminal.app, then pasting the following and hit enter:
 

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -2,11 +2,15 @@
 
 <!-- toc -->
 
-## Video Driver
+## Changing Video Drivers
 
+### From Preferences Screen
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
-changing the video driver in the preferences screen, then restarting Anki.
+changing the video driver in the preferences screen by navigating to *Anki >
+Preferences* and then selecting the driver from the dropdown menu. After that it
+is necessary to restart Anki.
 
+### From Terminal.app
 Older Anki versions did not provide an option in the preferences, but allowed
 you to adjust the driver by opening Terminal.app, then pasting the following and hit enter:
 

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -4,13 +4,13 @@
 
 ## Change the Video Driver
 
-### Changing the Driver from the Preferences Screen
+### Changing the Driver From the Preferences Screen
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
 changing the video driver in the preferences screen by navigating to **Anki →
 Preferences** and then selecting the driver from the dropdown menu. After that it
 is necessary to restart Anki.
 
-### Changing the Driver from Terminal.app
+### Changing the Driver From Terminal.app
 Older Anki versions did not provide an option in the preferences, but allowed
 you to adjust the driver by opening Terminal.app, then pasting the following and hit enter:
 

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -6,8 +6,8 @@
 
 ### From Preferences Screen
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
-changing the video driver in the preferences screen by navigating to *Anki >
-Preferences* and then selecting the driver from the dropdown menu. After that it
+changing the video driver in the preferences screen by navigating to **Anki →
+Preferences** and then selecting the driver from the dropdown menu. After that it
 is necessary to restart Anki.
 
 ### From Terminal.app

--- a/src/platform/windows/display-issues.md
+++ b/src/platform/windows/display-issues.md
@@ -9,7 +9,7 @@ may not work, or may cause display issues such as missing menubars, blank
 windows, and so on. Which one works best will depend on your computer.
 
 
-## Changing the driver with the preferences screen
+## Changing the driver from the Preferences Screen
 In Anki 23.10+, you can change the graphics driver from preferences screen by
 navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.

--- a/src/platform/windows/display-issues.md
+++ b/src/platform/windows/display-issues.md
@@ -9,13 +9,13 @@ may not work, or may cause display issues such as missing menubars, blank
 windows, and so on. Which one works best will depend on your computer.
 
 
-## Changing the Driver from the Preferences Screen
+## Changing the Driver From the Preferences Screen
 In Anki 23.10+, you can change the graphics driver from preferences screen by
 navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.
 
 
-## Changing the Driver from the Command Line
+## Changing the Driver From the Command Line
 If you run into display issues, you can try switching to software mode via cmd:
 
 ```bat

--- a/src/platform/windows/display-issues.md
+++ b/src/platform/windows/display-issues.md
@@ -15,7 +15,7 @@ navigating to *Tools > Preferences* and then selecting the driver from the
 dropdown menu.
 
 
-## Changing the driver with cmd / PowerShell
+## Changing the driver from the command line
 If you run into display issues, you can try switching to software mode via cmd:
 
 ```bat

--- a/src/platform/windows/display-issues.md
+++ b/src/platform/windows/display-issues.md
@@ -11,7 +11,7 @@ windows, and so on. Which one works best will depend on your computer.
 
 ## Changing the driver with the preferences screen
 In Anki 23.10+, you can change the graphics driver from preferences screen by
-navigating to *Tools > Preferences* and then selecting the driver from the
+navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.
 
 

--- a/src/platform/windows/display-issues.md
+++ b/src/platform/windows/display-issues.md
@@ -1,4 +1,4 @@
-# Windows display issues
+# Windows Display Issues
 
 <!-- toc -->
 
@@ -9,13 +9,13 @@ may not work, or may cause display issues such as missing menubars, blank
 windows, and so on. Which one works best will depend on your computer.
 
 
-## Changing the driver from the Preferences Screen
+## Changing the Driver from the Preferences Screen
 In Anki 23.10+, you can change the graphics driver from preferences screen by
 navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.
 
 
-## Changing the driver from the Command Line
+## Changing the Driver from the Command Line
 If you run into display issues, you can try switching to software mode via cmd:
 
 ```bat
@@ -32,7 +32,7 @@ It will not print anything. You can then start Anki again.
 
 To revert to the default behaviour, change `software` to `auto`, or delete that file.
 
-## Full screen
+## Full Screen
 
 Anki 2.1.50+ comes with a full screen mode, but due to various issues, it had to
 be disabled while `OpenGL` is used. Turning on software rendering as described

--- a/src/platform/windows/display-issues.md
+++ b/src/platform/windows/display-issues.md
@@ -15,7 +15,7 @@ navigating to **Tools → Preferences** and then selecting the driver from the
 dropdown menu.
 
 
-## Changing the driver from the command line
+## Changing the driver from the Command Line
 If you run into display issues, you can try switching to software mode via cmd:
 
 ```bat

--- a/src/platform/windows/display-issues.md
+++ b/src/platform/windows/display-issues.md
@@ -8,6 +8,14 @@ other options that are faster: _OpenGL_ and _ANGLE_. They are faster, but they
 may not work, or may cause display issues such as missing menubars, blank
 windows, and so on. Which one works best will depend on your computer.
 
+
+## Changing the driver with the preferences screen
+In Anki 23.10+, you can change the graphics driver from preferences screen by
+navigating to *Tools > Preferences* and then selecting the driver from the
+dropdown menu.
+
+
+## Changing the driver with cmd / PowerShell
 If you run into display issues, you can try switching to software mode via cmd:
 
 ```bat
@@ -23,8 +31,6 @@ echo software > $env:APPDATA\Anki2\gldriver6
 It will not print anything. You can then start Anki again.
 
 To revert to the default behaviour, change `software` to `auto`, or delete that file.
-
-In Anki 23.10+, you can also change the graphics driver from preferences screen.
 
 ## Full screen
 

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -35,7 +35,7 @@ then start Anki again to see if the problem has gone away.
 
 If you're using Linux, please make sure you can reproduce the error using the
 packaged version on the Anki website, as distros often distribute [broken
-versions](https://anki.tenderapp.com/kb/anki-ecosystem/third-party-linux-packages-and-source-builds-are-not-supported).
+versions](platform/linux/distro-packages.md).
 
 **4. Check your database**
 

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -28,8 +28,8 @@ report.
 
 **3. Check your Anki version**
 
-You can find the version you're using in the **Help → About** or **Anki → About
-menu**. If the version you're using is not the latest version published on
+You can find the version you're using in the **Help → About** or **Anki →
+About** menu. If the version you're using is not the latest version published on
 <https://apps.ankiweb.net>, please close Anki, install the latest version, and
 then start Anki again to see if the problem has gone away.
 

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -37,9 +37,9 @@ Crashes and display issues can be caused by the video driver. Changing to a
 different video driver may help. Make sure you try all the driver options and
 restart Anki after each change.
 
-If you're using Anki version 23.10 or above, the easiest way is to open *Tools >
-Preferences* (or *Anki > Preferences* if you're on a Mac) and change the driver
-from the dropdown menu.
+If you're using Anki version 23.10 or above, the easiest way is to open
+**Tools → Preferences** (or **Anki → Preferences** if you're on a Mac) and
+change the driver from the dropdown menu.
 
 If you are on an older Anki version or if you cannot access the preferences for
 some reason, you can use the command-line instructions instead and manually

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -2,7 +2,7 @@
 
 If you encounter a problem with Anki, please try the following steps in order:
 
-**1. Restart Anki**
+### 1. Restart Anki
 
 Please close Anki, then start it again.
 
@@ -13,7 +13,7 @@ circumstances.
 
 If the problem does not occur again, you can skip the following steps.
 
-**2. Check add-ons**
+### 2. Check add-ons
 
 Please close Anki, then open it in safe mode by holding down the
 <kbd>Shift</kbd> key while starting Anki. Keep holding <kbd>Shift</kbd> down
@@ -26,7 +26,7 @@ out which add-on is causing the problem. Then please report the issue to the
 add-on author, using the Copy Debug Info button, and pasting that into the
 report.
 
-**3. Check your Anki version**
+### 3. Check your Anki version
 
 You can find the version you're using in the **Help → About** or **Anki →
 About** menu. If the version you're using is not the latest version published on
@@ -37,16 +37,16 @@ If you're using Linux, please make sure you can reproduce the error using the
 packaged version on the Anki website, as distros often distribute [broken
 versions](platform/linux/distro-packages.md).
 
-**4. Check your database**
+### 4. Check your database
 
 After restarting Anki, please try the **Tools → Check Database** menu item to
 make sure your collection doesn't have any problems.
 
-**5. Restart your computer**
+### 5. Restart your computer
 
 Sometimes restarting your computer may help.
 
-**6. Change the Video Driver**
+### 6. Change the Video Driver
 
 Crashes and display issues can be caused by the video driver. Changing to a
 different video driver may help. Make sure you try all the driver options and
@@ -64,12 +64,12 @@ change the gldriver file:
 - [Mac](https://docs.ankiweb.net/platform/mac/display-issues.html)
 - [Linux](https://docs.ankiweb.net/platform/linux/display-issues.html)
 
-**7. Reset window sizes**
+### 7. Reset window sizes
 
 Sometimes pressing 'reset window sizes' button in the preferences screen
 immediately after starting Anki will help.
 
-**8. If the problem remains**
+### 8. If the problem remains
 
 If you've confirmed you are using the latest Anki version, and are still
 receiving errors when starting Anki while holding down the shift key,

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -42,7 +42,7 @@ Preferences* (or *Anki > Preferences* if you're on a Mac) and change the driver
 from the dropdown menu.
 
 If you are on an older Anki version or if you cannot access the preferences for
-some reason, you can use the command-line instructions instead and manualy
+some reason, you can use the command-line instructions instead and manually
 change the gldriver file:
 
 - [Windows](https://docs.ankiweb.net/platform/windows/display-issues.html)

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -6,26 +6,41 @@ If you encounter a problem with Anki, please try the following steps in order:
 
 Please close Anki, then start it again.
 
-If you are unable to close Anki because of an error message, you can either terminate Anki using your task manager, or restart your computer. Anki saves periodically, so you should not lose more than a few minutes of work in most circumstances.
+If you are unable to close Anki because of an error message, you can either
+terminate Anki using your task manager, or restart your computer. Anki saves
+periodically, so you should not lose more than a few minutes of work in most
+circumstances.
 
 If the problem does not occur again, you can skip the following steps.
 
 **2. Check add-ons**
 
-Please close Anki, then open it in safe mode by holding down the <kbd>Shift</kbd> key while starting Anki. Keep holding <kbd>Shift</kbd> down until the on-screen message informs you that Anki has started in safe mode. 
+Please close Anki, then open it in safe mode by holding down the
+<kbd>Shift</kbd> key while starting Anki. Keep holding <kbd>Shift</kbd> down
+until the on-screen message informs you that Anki has started in safe mode. 
 
-If the problem goes away, that indicates an add-on is causing the problem. Remove any add-ons you don't need, and disable half of the others. If the problem continues, try the other half. Repeat
-the process until you've figured out which add-on is causing the problem. Then please report the issue to the add-on author, using the Copy Debug Info button, and pasting that into the report.
+If the problem goes away, that indicates an add-on is causing the problem.
+Remove any add-ons you don't need, and disable half of the others. If the
+problem continues, try the other half. Repeat the process until you've figured
+out which add-on is causing the problem. Then please report the issue to the
+add-on author, using the Copy Debug Info button, and pasting that into the
+report.
 
 **3. Check your Anki version**
 
-You can find the version you're using in the Help>About or Anki>About menu. If the version you're using is not the latest version published on <https://apps.ankiweb.net>, please close Anki, install the latest version, and then start Anki again to see if the problem has gone away.
+You can find the version you're using in the **Help → About** or **Anki → About
+menu**. If the version you're using is not the latest version published on
+<https://apps.ankiweb.net>, please close Anki, install the latest version, and
+then start Anki again to see if the problem has gone away.
 
-If you're using Linux, please make sure you can reproduce the error using the packaged version on the Anki website, as distros often distribute [broken versions](https://anki.tenderapp.com/kb/anki-ecosystem/third-party-linux-packages-and-source-builds-are-not-supported).
+If you're using Linux, please make sure you can reproduce the error using the
+packaged version on the Anki website, as distros often distribute [broken
+versions](https://anki.tenderapp.com/kb/anki-ecosystem/third-party-linux-packages-and-source-builds-are-not-supported).
 
 **4. Check your database**
 
-After restarting Anki, please try the Tools>Check Database menu item to make sure your collection doesn't have any problems.
+After restarting Anki, please try the **Tools → Check Database** menu item to
+make sure your collection doesn't have any problems.
 
 **5. Restart your computer**
 
@@ -56,4 +71,7 @@ immediately after starting Anki will help.
 
 **8. If the problem remains**
 
-If you're confirmed you are using the latest Anki version, and are still receiving errors when starting Anki while holding down the shift key, please [report the problem](./getting-help.md), including the next error you receive in your post.
+If you're confirmed you are using the latest Anki version, and are still
+receiving errors when starting Anki while holding down the shift key,
+please [report the problem](./getting-help.md), including the next error you
+receive in your post.

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -71,7 +71,7 @@ immediately after starting Anki will help.
 
 **8. If the problem remains**
 
-If you're confirmed you are using the latest Anki version, and are still
+If you've confirmed you are using the latest Anki version, and are still
 receiving errors when starting Anki while holding down the shift key,
 please [report the problem](./getting-help.md), including the next error you
 receive in your post.

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -34,8 +34,16 @@ Sometimes restarting your computer may help.
 **6. Change the Video Driver**
 
 Crashes and display issues can be caused by the video driver. Changing to a
-different video driver in the preferences screen or via the gldriver file may
-help. Make sure you try all three options and restart Anki after each change.
+different video driver may help. Make sure you try all the driver options and
+restart Anki after each change.
+
+If you're using Anki version 23.10 or above, the easiest way is to open *Tools >
+Preferences* (or *Anki > Preferences* if you're on a Mac) and change the driver
+from the dropdown menu.
+
+If you are on an older Anki version or if you cannot access the preferences for
+some reason, you can use the command-line instructions instead and manualy
+change the gldriver file:
 
 - [Windows](https://docs.ankiweb.net/platform/windows/display-issues.html)
 - [Mac](https://docs.ankiweb.net/platform/mac/display-issues.html)


### PR DESCRIPTION
Fixes: #334

I separated the linked pages into subheaders because there are users saying that the sections in the manual cause "information overload". Now they are really short and shouldn't be an issue anymore for those people.

I also moved the mention of the preferences screen to the top and added info on how to open the preferences.