### PR TITLE
Change from single quote `'` to double quote `"`

### DIFF
--- a/src/deck-options.md
+++ b/src/deck-options.md
@@ -395,7 +395,7 @@ become available, and SM-2 specific options, such as **Graduating interval**,
 - Please ensure all of your Anki clients support FSRS. Anki 23.10, AnkiMobile 23.10,
   and AnkiWeb all support it. AnkiDroid supports it in 2.17+. If
   one of your clients doesn't support it, things will not work correctly.
-- If you previously used the 'custom scheduling' version of FSRS, please make
+- If you previously used the "custom scheduling" version of FSRS, please make
   sure you clear out the custom scheduling section before enabling FSRS.
 
 ### A Short Guide

--- a/src/editing.md
+++ b/src/editing.md
@@ -5,7 +5,7 @@
 ## Adding Cards and Notes
 
 Recall from the [basics](getting-started.md) that in Anki we add notes rather than
-cards, and Anki creates cards for us. Click "Add" in the [main window](studying.md#decks),
+cards, and Anki creates cards for us. Click **Add** in the [main window](studying.md#decks),
 and the Add Notes window will appear.
 
 ![Add Screen](media/add_screen.png)
@@ -17,7 +17,7 @@ selected.
 
 The top right of the window shows us the [deck](getting-started.md#decks) cards will be added to. If
 you would like to add cards to a new deck, you can click on the deck name
-button and then click "Add".
+button and then click **Add**.
 
 Below the note type, you'll see some buttons, and an area labelled
 "Front" and "Back". Front and Back are called [fields](getting-started.md#notes--fields), and you can add,
@@ -328,7 +328,7 @@ key strips formatting" to modify the default behaviour.
 
 ## Cloze Deletion
 
-"Cloze deletion" is the process of hiding one or more words in a
+_Cloze deletion_ is the process of hiding one or more words in a
 sentence. For example, if you have the sentence:
 
     Canberra was founded in 1913.

--- a/src/editing.md
+++ b/src/editing.md
@@ -5,7 +5,7 @@
 ## Adding Cards and Notes
 
 Recall from the [basics](getting-started.md) that in Anki we add notes rather than
-cards, and Anki creates cards for us. Click 'Add' in the [main window](studying.md#decks),
+cards, and Anki creates cards for us. Click "Add" in the [main window](studying.md#decks),
 and the Add Notes window will appear.
 
 ![Add Screen](media/add_screen.png)
@@ -126,7 +126,7 @@ Alternatively you can also drag and drop the field names to re-order them. To do
 that, use your mouse or finger to drag the field to the desired position. An indicator will
 show you where the field will be moved to.
 
-Do not use 'Tags', 'Type', 'Deck', 'Card', or 'FrontSide' as field
+Do not use "Tags", "Type", "Deck", "Card", or "FrontSide" as field
 names, as they are [special fields](templates/fields.md#special-fields) and will not work
 properly.
 
@@ -294,7 +294,7 @@ of the text, whether the selected text is bold, etc. The next three buttons allo
 You can use the paper-clip button to select audio, images, and videos from
 your computer's hard drive and attach them to your notes. Alternatively, you
 can copy the media onto your computer's clipboard (for instance, by
-right-clicking an image on the web and choosing 'Copy Image') and paste
+right-clicking an image on the web and choosing "Copy Image") and paste
 it into the field that you want to place it in. For more information
 about media, please see the [media](media.md) section.
 
@@ -328,7 +328,7 @@ key strips formatting" to modify the default behaviour.
 
 ## Cloze Deletion
 
-'Cloze deletion' is the process of hiding one or more words in a
+"Cloze deletion" is the process of hiding one or more words in a
 sentence. For example, if you have the sentence:
 
     Canberra was founded in 1913.
@@ -339,7 +339,7 @@ become:
     Canberra was founded in [...].
 
 Sometimes sections that have been removed in this fashion are said to be
-'occluded'.
+"occluded".
 
 For more information on why you might want to use cloze deletion, see
 Rule 5 [here](https://super-memory.com/articles/20rules.htm).

--- a/src/exporting.md
+++ b/src/exporting.md
@@ -3,7 +3,7 @@
 <!-- toc -->
 
 Exporting allows you to save part of your collection as a text file or
-packaged Anki deck. To export, click the File menu and choose 'Export'.
+packaged Anki deck. To export, click the File menu and choose "Export".
 
 ## Text Files
 
@@ -24,7 +24,7 @@ the text is exported with all the HTML formatting embedded in it.
 
 ## Packaged Decks
 
-A 'packaged deck' consists of cards, notes, note types, and any sounds or
+A "packaged deck" consists of cards, notes, note types, and any sounds or
 images bundled up into a file ending with .apkg or .colpkg. You can use
 packaged decks to transfer cards between people, or for backing up parts
 of your collection.
@@ -34,7 +34,7 @@ There are two different kinds of packaged decks.
 ### Collection (.colpkg)
 
 When you export all decks with scheduling included, this is called a
-'collection package'. Anki will copy your entire collection into a file
+"collection package". Anki will copy your entire collection into a file
 ending in .colpkg, and place it on your desktop. A collection package is
 used to back up your collection, or copy it to another device.
 

--- a/src/exporting.md
+++ b/src/exporting.md
@@ -3,7 +3,7 @@
 <!-- toc -->
 
 Exporting allows you to save part of your collection as a text file or
-packaged Anki deck. To export, click the File menu and choose "Export".
+packaged Anki deck. To export, click the File menu and choose **Export**.
 
 ## Text Files
 

--- a/src/files.md
+++ b/src/files.md
@@ -249,7 +249,7 @@ Copy the `sqlite3.exe` program and your deck to your desktop. Then go to
 
 If you're on a recent Windows, the command prompt may not start on your
 desktop. If you don't see desktop displayed in the command prompt, type
-something like the following, replacing 'administrator' with your login
+something like the following, replacing "administrator" with your login
 name.
 
     cd C:\Users\Administrator\Desktop

--- a/src/filtered-decks.md
+++ b/src/filtered-decks.md
@@ -8,8 +8,8 @@ limit of new cards. This is generally useful, as it ensures you don't
 spend more time studying than necessary. But sometimes it can be useful
 to step outside of these normal limits, such as when you need to review
 for a test, focus on particular material, and so on. To make this
-possible, Anki provides a different type of deck called a 'filtered
-deck'.
+possible, Anki provides a different type of deck called a "filtered
+deck".
 
 Filtered decks offer a lot of possibilities. They can be used for
 previewing cards, cramming cards before a test, studying particular
@@ -32,7 +32,7 @@ Here is a summary of each of the options:
 
 **Increase today's new card limit**\
 Add more new cards to the deck you are currently studying. Note that
-unlike other options, this does 'not' create a new filtered deck, it
+unlike other options, this does "not" create a new filtered deck, it
 modifies the existing deck.
 
 **Increase today's review card limit**\
@@ -66,8 +66,8 @@ cards in the deck.
 ## Home Decks
 
 When a card is moved to a filtered deck, it retains a link to the deck,
-from which it came. That previous deck is said to be the card's 'home
-deck'.
+from which it came. That previous deck is said to be the card's "home
+deck".
 
 Cards automatically return to their home deck after they are studied in
 the filtered deck. This can be after a single review, or after multiple
@@ -87,7 +87,7 @@ It is also possible to move all cards back to their home decks at once:
 ## Creating Manually
 
 Advanced users can create filtered decks with arbitrary search strings
-(or 'filters'),
+(or "filters"),
 instead of relying on the preset filters. To create a filtered deck manually,
 choose Create Filtered Deck from the Tools menu.
 
@@ -153,7 +153,7 @@ Display cards with the earliest due date first.
 
 **Latest added first**\
 Display cards that you have most recently added to the deck first.
-(This is the opposite of 'Order added'.)
+(This is the opposite of "Order added".)
 
 **Relative overdueness**\
 Display cards that you're most likely to have forgotten first. This is useful if

--- a/src/getting-help.md
+++ b/src/getting-help.md
@@ -29,7 +29,7 @@ Instead, please provide as much detail as you can. For example:
 > "When I double-click on the Anki icon, an error message pops up. I tried
 > searching for the error on Google, but couldn't find anything useful. I have
 > copied and pasted the error message to the bottom of my post. I followed the
-> steps on the 'When problems occur' page, but the error message does not go
+> steps on the "When problems occur" page, but the error message does not go
 > away. What should I do?"
 
 This is a much better question. It tells us:

--- a/src/importing/text-files.md
+++ b/src/importing/text-files.md
@@ -77,7 +77,7 @@ This is an example of a valid file where the first line is ignored (\#):
 ## Spreadsheets and UTF-8
 
 If you have non-Latin characters in your file (such as accents, Japanese
-and so on), Anki expects files to be saved in a 'UTF-8 encoding'. The
+and so on), Anki expects files to be saved in a "UTF-8 encoding". The
 easiest way to do this is to use the free LibreOffice spreadsheet
 program instead of Excel to edit your file, as it supports UTF-8 easily,
 and also exports multi-line content properly, unlike Excel. If you wish
@@ -127,7 +127,7 @@ Alternatively, you can use the [find and replace](../browsing.md) feature
 in the browse screen to update all the fields at once. If each field
 contains text like "myaudio", and you wish to make it play a sound,
 you’d search for (.\*) and replace it with "\[sound:\\1.mp3\]", with the
-'regular expressions' option enabled.
+"regular expressions" option enabled.
 
 When importing a text file with these references, you must make sure to
 enable the "Allow HTML" option.
@@ -147,7 +147,7 @@ Another option for importing large amounts of media at once is to use
 the [media import add-on](https://ankiweb.net/shared/info/129299120).
 This add-on will automatically create notes for all files in a folder
 you select, with the filenames on the front (minus the file extension,
-so if you have a file named apple.jpg, the front would say 'apple') and
+so if you have a file named apple.jpg, the front would say "apple") and
 the images or audio on the back. If you would like a different
 arrangement of media and filenames, you can [change the note type](../browsing.md) of the created cards afterwards.
 
@@ -162,9 +162,9 @@ imported file. A drop-down box in the import screen allows you to change
 this behaviour, to either ignore duplicates completely, or import them
 as new notes instead of updating existing ones.
 
-The 'match scope' setting controls how duplicates are identified. When
-'note type' is selected, Anki will identify a duplicate if another note
-with the same note type has the same first field. When set to 'note type and deck',
+The "match scope" setting controls how duplicates are identified. When
+"note type" is selected, Anki will identify a duplicate if another note
+with the same note type has the same first field. When set to "note type and deck",
 a duplicate will only be flagged if the existing note also happens to be
 in the deck you are importing into.
 

--- a/src/importing/text-files.md
+++ b/src/importing/text-files.md
@@ -127,7 +127,7 @@ Alternatively, you can use the [find and replace](../browsing.md) feature
 in the browse screen to update all the fields at once. If each field
 contains text like "myaudio", and you wish to make it play a sound,
 you’d search for (.\*) and replace it with "\[sound:\\1.mp3\]", with the
-"regular expressions" option enabled.
+**regular expressions** option enabled.
 
 When importing a text file with these references, you must make sure to
 enable the "Allow HTML" option.
@@ -162,9 +162,9 @@ imported file. A drop-down box in the import screen allows you to change
 this behaviour, to either ignore duplicates completely, or import them
 as new notes instead of updating existing ones.
 
-The "match scope" setting controls how duplicates are identified. When
-"note type" is selected, Anki will identify a duplicate if another note
-with the same note type has the same first field. When set to "note type and deck",
+The **match scope** setting controls how duplicates are identified. When
+**note type** is selected, Anki will identify a duplicate if another note
+with the same note type has the same first field. When set to **note type and deck**,
 a duplicate will only be flagged if the existing note also happens to be
 in the deck you are importing into.
 

--- a/src/leeches.md
+++ b/src/leeches.md
@@ -5,7 +5,7 @@
 Leeches are cards that you keep forgetting. Because they require so
 many reviews, they take up a lot more of your time, compared to other cards.
 
-Anki can help you identify leeches. Each time a review card 'lapses' (is 
+Anki can help you identify leeches. Each time a review card "lapses" (is 
 failed while it is in review mode), a counter increases. When this counter
 reaches 8, Anki tags the note as a leech and suspends the card. The 
 threshold, and whether to suspend or not, can be adjusted in the
@@ -41,7 +41,7 @@ useful for future reference, you can leave it suspended.
 
 ## Waiting
 
-Some leeches are caused by 'interference'. For example, an English
+Some leeches are caused by "interference". For example, an English
 learner may have recently learnt the words "disappoint" and "disappear".
 As they look similar, the learner may find themselves confusing the two
 when trying to answer. In such situations, it’s often helpful to

--- a/src/math.md
+++ b/src/math.md
@@ -39,7 +39,7 @@ If you want to use newlines in a MathJax expression, please use
 MathJax from working correctly.
 
 Anki includes built in support for mhchem for rendering chemical
-equations. Please see the 'chemical equations' section and the following
+equations. Please see the "chemical equations" section and the following
 sections for more information:
 <https://mhchem.github.io/MathJax-mhchem/>
 
@@ -81,7 +81,7 @@ LaTeX code can contain malicious commands that can read or write non-Anki
 data on your computer. For this reason, recent Anki versions will refuse to
 generate LaTeX images by default.
 
-If you wish to use LaTeX on your own cards, you will need to enable the 'Generate LaTeX images' option in the preferences screen.
+If you wish to use LaTeX on your own cards, you will need to enable the "Generate LaTeX images" option in the preferences screen.
 
 **We strongly recommend you do not enable this option if you use shared decks, or think
 you will import shared decks in the future, as you are potentially giving any shared
@@ -151,9 +151,9 @@ will produce this when the flashcard is viewed:
 
 ![convergence question](math/convergence_question.png)
 
-The formula in the example above is called a 'text formula', because it
+The formula in the example above is called a "text formula", because it
 is displayed right within the non-mathematical text. In contrast, the
-following example shows a 'displayed formula':
+following example shows a "displayed formula":
 
     Does the sum below converge?
 
@@ -161,7 +161,7 @@ following example shows a 'displayed formula':
 
 ![convergence question 2](math/convergence_question_2.png)
 
-'Text formulas' and 'display formulas' are the most common type of LaTeX
+"Text formulas" and "display formulas" are the most common type of LaTeX
 expressions, so Anki provides abbreviated versions of them. Expressions
 of the form:
 

--- a/src/math.md
+++ b/src/math.md
@@ -81,7 +81,7 @@ LaTeX code can contain malicious commands that can read or write non-Anki
 data on your computer. For this reason, recent Anki versions will refuse to
 generate LaTeX images by default.
 
-If you wish to use LaTeX on your own cards, you will need to enable the "Generate LaTeX images" option in the preferences screen.
+If you wish to use LaTeX on your own cards, you will need to enable the **Generate LaTeX images** option in the preferences screen.
 
 **We strongly recommend you do not enable this option if you use shared decks, or think
 you will import shared decks in the future, as you are potentially giving any shared

--- a/src/platform/linux/installing.md
+++ b/src/platform/linux/installing.md
@@ -39,7 +39,7 @@ sudo ./install.sh
 
 On some Linux systems, you may need to use `tar xaf --use-compress-program=unzstd`.
 
-4. You can then start Anki by typing "anki" and hitting enter. If you encounter
+4. You can then start Anki by typing `anki` and hitting enter. If you encounter
    any issues, please see the links on the left.
 
 ## Upgrading

--- a/src/platform/linux/installing.md
+++ b/src/platform/linux/installing.md
@@ -39,7 +39,7 @@ sudo ./install.sh
 
 On some Linux systems, you may need to use `tar xaf --use-compress-program=unzstd`.
 
-4. You can then start Anki by typing 'anki' and hitting enter. If you encounter
+4. You can then start Anki by typing "anki" and hitting enter. If you encounter
    any issues, please see the links on the left.
 
 ## Upgrading

--- a/src/stats.md
+++ b/src/stats.md
@@ -76,7 +76,7 @@ You can change this to all history scope or deck life scope at the top. (The
 
 At the top of the statistics window is a brief list of textual
 statistics about the reviews that you have completed today. A “review”
-in this context is 'one answering of a card', so a card might count as
+in this context is "one answering of a card", so a card might count as
 multiple reviews if it needed to be seen multiple times, and a learning
 card answered also counts as a “review.” A couple of the stats whose
 meaning may not be immediately obvious:
@@ -84,7 +84,7 @@ meaning may not be immediately obvious:
 **Again Count**\
 This is the number of reviews that you have failed (i.e., pressed Again
 on). The correct percentage listed afterwards is the number of cards you
-did 'not' fail divided by the total number of cards you studied.
+did "not" fail divided by the total number of cards you studied.
 
 **Learn, Review, Relearn, Filtered**\
 The number of reviews that were learning cards, review cards, relearning
@@ -234,19 +234,19 @@ with is called [SQLite Browser](http://sqlitebrowser.org/), which will
 allow you to look around the database as well as export a CSV version of
 tables for import into another program.
 
-The most important table for statistics is the 'revlog' table, which
+The most important table for statistics is the "revlog" table, which
 stores an entry for each review that you conduct. The columns are as
 follows:
 
 **id**\
 The time at which the review was conducted, as the number of
 milliseconds that had passed since midnight UTC on January 1, 1970.
-(This is sometimes known as 'Unix epoch time', especially when in
+(This is sometimes known as "Unix epoch time", especially when in
 straight seconds instead of milliseconds.)
 
 **cid**\
 The ID of the card that was reviewed. You can look up this value in the
-id field of the 'cards' table to get more information about the card,
+id field of the "cards" table to get more information about the card,
 although note that the card could have changed between when the revlog
 entry was recorded and when you are looking it up. It is also the
 millisecond timestamp of the card’s creation time.

--- a/src/studying.md
+++ b/src/studying.md
@@ -15,7 +15,7 @@ cards for that day will be also displayed here.
 
 ![Decks screen](media/decks_screen.png)
 
-When you click on a deck, it will become the 'current deck', and Anki
+When you click on a deck, it will become the "current deck", and Anki
 will change to the study screen. You can return to the deck list at any time by clicking on “Decks” at
 the top of the main window. (You can also use the Study
 Deck action in the menu to select a new deck from the keyboard, or you
@@ -27,7 +27,7 @@ delete the deck, change its [options](deck-options.md), or [export](exporting.md
 ## Study Overview
 
 After clicking on a deck to study, you’ll see a screen that shows you
-how many cards are due today. This is called the 'deck overview' screen:
+how many cards are due today. This is called the "deck overview" screen:
 
 ![Study overview](media/study_overview.png)
 
@@ -192,10 +192,10 @@ can change the order in the [browser](browsing.md).
 Recall from [the basics](getting-started.md) that Anki can create more than one
 card for each thing you input, such as a front→back card and a
 back→front card, or two different cloze deletions from the same text.
-These related cards are called 'siblings'.
+These related cards are called "siblings".
 
 When you answer a card that has siblings, Anki can prevent the card’s
-siblings from being shown in the same session by automatically 'burying'
+siblings from being shown in the same session by automatically "burying"
 them. Buried cards are hidden from review until the clock rolls over to
 a new day or you manually unbury them using the “Unbury” button that’s
 visible at the bottom of the [deck overview](studying.md#study-overview) screen. Anki
@@ -227,7 +227,7 @@ find it convenient to answer most cards with <kbd>Space</kbd> and keep one finge
 on <kbd>1</kbd> for when they forget.
 
 The "Study Deck" item in the Tools menu allows you to quickly switch to
-a deck with the keyboard. You can trigger it with the '/' key. When
+a deck with the keyboard. You can trigger it with the "/" key. When
 opened, it will display all of your decks and show a filter area at the
 top. As you type characters, Anki will display only decks matching the
 characters you type. You can add a space to separate multiple search

--- a/src/studying.md
+++ b/src/studying.md
@@ -227,7 +227,7 @@ find it convenient to answer most cards with <kbd>Space</kbd> and keep one finge
 on <kbd>1</kbd> for when they forget.
 
 The "Study Deck" item in the Tools menu allows you to quickly switch to
-a deck with the keyboard. You can trigger it with the "/" key. When
+a deck with the keyboard. You can trigger it with the <kbd>/</kbd> key. When
 opened, it will display all of your decks and show a filter area at the
 top. As you type characters, Anki will display only decks matching the
 characters you type. You can add a space to separate multiple search

--- a/src/sync-server.md
+++ b/src/sync-server.md
@@ -14,7 +14,7 @@ Things to be aware of:
 - Third-party sync servers also exist. No testing is done against them, and
   they tend to take time to catch up when the sync protocol changes, so they
   are not recommended.
-- The messages inside Anki will use the term 'AnkiWeb' even if a custom server
+- The messages inside Anki will use the term "AnkiWeb" even if a custom server
   has been configured, (e.g "Cannot connect to AnkiWeb" when your server is down).
 
 ## Installing/Running

--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -34,7 +34,7 @@ line, and then the Back field”.
 
 The "id=answer" part tells Anki where the divider is between the
 question and the answer. This allows Anki to automatically scroll to the
-spot where the answer starts when you press "show answer" on a long card
+spot where the answer starts when you press **show answer** on a long card
 (especially useful on mobile devices with small screens). If you don’t
 want a horizontal line at the beginning of the answer, you can use
 another HTML element such as a paragraph or div instead.
@@ -165,7 +165,7 @@ As with other fields, special field names are case sensitive - you must use
 ## Hint Fields
 
 It’s possible to add a field to the front or back of a card, but make it
-hidden until you explicitly show it. We call this a "hint field". Before
+hidden until you explicitly show it. We call this a _hint field_. Before
 adding a hint, please bear in mind that the easier you make it to answer
 a question in Anki, the less likely you are to remember that question
 when you encounter it in real life. Please have a read about the

--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -32,9 +32,9 @@ The default back template will look something like this:
 This means “show me the text that’s on the front side, then a divider
 line, and then the Back field”.
 
-The 'id=answer' part tells Anki where the divider is between the
+The "id=answer" part tells Anki where the divider is between the
 question and the answer. This allows Anki to automatically scroll to the
-spot where the answer starts when you press 'show answer' on a long card
+spot where the answer starts when you press "show answer" on a long card
 (especially useful on mobile devices with small screens). If you don’t
 want a horizontal line at the beginning of the answer, you can use
 another HTML element such as a paragraph or div instead.
@@ -165,11 +165,11 @@ As with other fields, special field names are case sensitive - you must use
 ## Hint Fields
 
 It’s possible to add a field to the front or back of a card, but make it
-hidden until you explicitly show it. We call this a 'hint field'. Before
+hidden until you explicitly show it. We call this a "hint field". Before
 adding a hint, please bear in mind that the easier you make it to answer
 a question in Anki, the less likely you are to remember that question
 when you encounter it in real life. Please have a read about the
-'minimum information principle' on
+"minimum information principle" on
 <https://super-memory.com/articles/20rules.htm> before proceeding.
 
 First, you’ll need to add a field to store the hint in if you have not
@@ -395,8 +395,8 @@ Which will affect the following HTML for the answer comparison:
     <code id=typeans>...</code>
 
 Advanced users can override the default type-answer colors with the css
-classes 'typeGood', 'typeBad' and 'typeMissed'. AnkiMobile supports
-'typeGood' and 'typeBad', but not 'typeMissed'.
+classes "typeGood", "typeBad" and "typeMissed". AnkiMobile supports
+"typeGood" and "typeBad", but not "typeMissed".
 
 If you wish to override the size of the typing box and don’t want to
 change the font in the Fields dialog, you can override the default

--- a/src/templates/generation.md
+++ b/src/templates/generation.md
@@ -17,7 +17,7 @@ important material, or some of your cards don’t make sense reversed),
 you can select the “Basic (optional reversed card)” note type. This note
 type generates a forward-only card when you fill in only the first two
 fields; if you additionally enter something in the “Add Reverse” field
-(like a 'y'), Anki will generate a reverse card as well. The contents of
+(like a "y"), Anki will generate a reverse card as well. The contents of
 this field will never be displayed on a card.
 
 ## Card Generation & Deletion
@@ -123,7 +123,7 @@ Keep in mind that this only works when you place the
 conditional replacement code on the _front_ of the card; if you do this
 on the back, you will simply end up with cards with a blank back side.
 Similarly, since this works by checking if the front field would be
-empty, it is important to make sure you wrap the 'entire' front side in
+empty, it is important to make sure you wrap the "entire" front side in
 the conditional replacement; for instance, the following would not work
 as expected:
 

--- a/src/templates/intro.md
+++ b/src/templates/intro.md
@@ -15,7 +15,7 @@ Card templates are covered in some of the intro videos:
 
 ## The Templates Screen
 
-You can modify card templates by clicking the "Cards..." button inside the
+You can modify card templates by clicking the **Cards...** button inside the
 editing screen.
 
 
@@ -37,7 +37,7 @@ At the top right of the window is an Options button that gives you
 options to rename or reorder the cards, as well as the following two
 options:
 
-- The "Deck Override" option allows you to change the deck that cards
+- The **Deck Override** option allows you to change the deck that cards
   generated from the current card type will be placed into. By
   default, cards are placed into the deck you provide in the Add Notes
   window. If you set a deck here, that card type will be placed into
@@ -48,7 +48,7 @@ options:
   can check which deck the cards are currently going to by choosing
   Deck Override again.
 
-- The "Browser Appearance" option allows you to set different (perhaps
+- The **Browser Appearance** option allows you to set different (perhaps
   simplified) templates for display in the Question and Answer columns
   of the browser; see [browser appearance](styling.md#browser-appearance) for more
   information.

--- a/src/templates/intro.md
+++ b/src/templates/intro.md
@@ -37,7 +37,7 @@ At the top right of the window is an Options button that gives you
 options to rename or reorder the cards, as well as the following two
 options:
 
-- The 'Deck Override' option allows you to change the deck that cards
+- The "Deck Override" option allows you to change the deck that cards
   generated from the current card type will be placed into. By
   default, cards are placed into the deck you provide in the Add Notes
   window. If you set a deck here, that card type will be placed into
@@ -48,7 +48,7 @@ options:
   can check which deck the cards are currently going to by choosing
   Deck Override again.
 
-- The 'Browser Appearance' option allows you to set different (perhaps
+- The "Browser Appearance" option allows you to set different (perhaps
   simplified) templates for display in the Question and Answer columns
   of the browser; see [browser appearance](styling.md#browser-appearance) for more
   information.

--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -29,7 +29,7 @@ at the end.
 Whether the text should be aligned in the center, left, or right.
 
 **color**\
-The color of the text. Simple color names like 'blue', 'lightyellow',
+The color of the text. Simple color names like "blue", "lightyellow",
 and so on will work, or you can use HTML color codes to select arbitrary
 colors. Please see [this webpage](https://htmlcolorcodes.com/) for more
 information.
@@ -373,7 +373,7 @@ something like:
 }
 ```
 
-If you have a 'myclass' style, the following would show the text in
+If you have a "myclass" style, the following would show the text in
 yellow when night mode is enabled:
 
 ```css

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -66,7 +66,7 @@ change the gldriver file:
 
 ### 7. Reset window sizes
 
-Sometimes pressing "reset window sizes" button in the preferences screen
+Sometimes pressing **reset window sizes** button in the preferences screen
 immediately after starting Anki will help.
 
 ### 8. If the problem remains

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -66,7 +66,7 @@ change the gldriver file:
 
 ### 7. Reset window sizes
 
-Sometimes pressing 'reset window sizes' button in the preferences screen
+Sometimes pressing "reset window sizes" button in the preferences screen
 immediately after starting Anki will help.
 
 ### 8. If the problem remains


### PR DESCRIPTION
There were some single quote use, despite the README.md style guidelines recommending double quote use.