### PR TITLE
Add official apps to manual

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,7 +4,7 @@ description = "Anki's user manual. Anki is a flashcard program that makes learni
 language = "en"
 multilingual = false
 src = "src"
-title = "Anki Manual"
+title = "Anki Manual for Desktop"
 
 [build]
 create-missing = true

--- a/book.toml
+++ b/book.toml
@@ -4,7 +4,7 @@ description = "Anki's user manual. Anki is a flashcard program that makes learni
 language = "en"
 multilingual = false
 src = "src"
-title = "Anki Manual for Desktop"
+title = "Anki Manual"
 
 [build]
 create-missing = true

--- a/book.toml
+++ b/book.toml
@@ -4,7 +4,7 @@ description = "Anki's user manual. Anki is a flashcard program that makes learni
 language = "en"
 multilingual = false
 src = "src"
-title = "Anki Manual for Desktop"
+title = "Anki for Computers"
 
 [build]
 create-missing = true

--- a/book.toml
+++ b/book.toml
@@ -4,7 +4,7 @@ description = "Anki's user manual. Anki is a flashcard program that makes learni
 language = "en"
 multilingual = false
 src = "src"
-title = "Anki for Computers"
+title = "Anki Manual for Desktop"
 
 [build]
 create-missing = true

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -4,7 +4,11 @@
 
 ## Installing & Upgrading
 
-Please see the instructions for your computer:
+The Anki ecosystem is made up of Anki, AnkiMobile, AnkiDroid, and AnkiWeb, all
+of which are linked from our [official website](https://apps.ankiweb.net).
+
+For instructions on how to install and upgrade Anki for your computer, please
+read the links below:
 
 - [Windows](./platform/windows/installing.md)
 - [Mac](./platform/mac/installing.md)


### PR DESCRIPTION
Fixes: #340 

This PR…
- changes the title to make it obvious that this is the manual for the desktop version of Anki
- includes the mention of other official apps copied from the [FAQ](https://faqs.ankiweb.net/anki-knockoffs.html).