### PR TITLE
Update Resource Link

### DIFF
--- a/src/resources.md
+++ b/src/resources.md
@@ -1,3 +1,3 @@
 # Resources
 
-You can find guides, templates, custom schedulers and other resources in Anki's crowdsourced [resource list](https://docs.google.com/document/d/1xWnF_r0z4cRNOHDeXGYOuUH3FsDAzdab8VUjx4lnzL4/edit?usp=drivesdk).
+You can find guides, templates, custom schedulers and other resources in [this resource list](https://forums.ankiweb.net/t/collection-of-anki-resources/60044).


### PR DESCRIPTION
I'm moving the resource list in GDocs to forums. This is what @dae originally wanted so shouldn't be an issue.

Link: https://forums.ankiweb.net/t/collection-of-anki-resources/60044