### PR TITLE
Document symlink behavior in styling section

### DIFF
--- a/src/media.md
+++ b/src/media.md
@@ -50,6 +50,11 @@ you should use Tools&gt;Check Media afterwards, to ensure the filenames are
 encoded correctly. If you skip this step, any filenames that are not compatible
 will be skipped when syncing.
 
+Anki doesn’t follow symbolic links in the media folder when syncing. If you
+rely on symlinks for including fonts, stylesheets, or other resources, these files
+may appear to work on desktop but fail on mobile. To ensure files sync properly, copy
+the actual files into the collection.media folder instead of using symlinks. 
+
 ## Supported Formats
 
 Anki uses a program called mpv (and mplayer as a fallback) in order to support

--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -309,6 +309,10 @@ or if you’re using Anki on a mobile device.
 Anki supports the most widely used font formats, such as TrueType (.ttf),
 OpenType (.otf), Web Open Font Format (.woff) and others.
 
+Anki doesn’t follow symbolic links in the media folder when syncing. Place your
+fonts, stylesheets, and other custom files directly in the `collection.media`
+folder instead of using symlinks.
+
 ### Add Font to Media Folder
 
 Once you have downloaded a supported font, such as "Arial.ttf", you have to add

--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -309,10 +309,6 @@ or if you’re using Anki on a mobile device.
 Anki supports the most widely used font formats, such as TrueType (.ttf),
 OpenType (.otf), Web Open Font Format (.woff) and others.
 
-Anki doesn’t follow symbolic links in the media folder when syncing. Place your
-fonts, stylesheets, and other custom files directly in the `collection.media`
-folder instead of using symlinks.
-
 ### Add Font to Media Folder
 
 Once you have downloaded a supported font, such as "Arial.ttf", you have to add


### PR DESCRIPTION
Users who rely on symlinks for custom CSS or font
files will find their files never make it up to
AnkiWeb and may be puzzled when they seem to work
on desktop.

Adding this note to the manual warns users up
front, prevents confusion, and should cut down on
future support questions related to styling.