### PR TITLE
Include the "--locked" flag in the suggested "cargo install" invocation

### DIFF
--- a/src/sync-server.md
+++ b/src/sync-server.md
@@ -63,7 +63,7 @@ From Anki 2.1.66+, you can alternatively build a Rust implementation of the stan
 Make sure you have Rustup installed.
 
 ```
-cargo install --git https://github.com/ankitects/anki.git --tag 2.1.66 anki-sync-server
+cargo install --locked --git https://github.com/ankitects/anki.git --tag 2.1.66 anki-sync-server
 ```
 
 Replace 2.1.66 with whatever the latest Anki version is.

--- a/src/sync-server.md
+++ b/src/sync-server.md
@@ -63,10 +63,10 @@ From Anki 2.1.66+, you can alternatively build a Rust implementation of the stan
 Make sure you have Rustup installed.
 
 ```
-cargo install --locked --git https://github.com/ankitects/anki.git --tag 2.1.66 anki-sync-server
+cargo install --locked --git https://github.com/ankitects/anki.git --tag 25.02.5 anki-sync-server
 ```
 
-Replace 2.1.66 with whatever the latest Anki version is.
+Replace 25.02.5 with whatever the latest Anki version is.
 
 Protobuf (protoc) will need to be installed.
 


### PR DESCRIPTION
I was unable to build the sync server (ankitects/anki#4031) until I included the `--locked` flag in the `cargo install` invocation. This seems to be the way the Dockerfile is built as well (as of the recent PR ankitects/anki#3856), so it seems like the manual should suggest using this flag too.

Since I was making changes in this area anyway, I bumped the example sync server version from 2.1.66 to 25.02.5.