### PR TITLE
Enable smart punctuation in mdBook output (fixes #382)

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -16,6 +16,7 @@ renderer = ["html"]
 git-repository-url = "https://github.com/ankitects/anki-manual/"
 cname = "docs.ankiweb.net"
 additional-css = ["css/misc.css", "css/kbd.css"]
+smart-punctuation = true
 mathjax-support = true
 
 [output.linkcheck]


### PR DESCRIPTION
Enables `smart-punctuation = true` in the `[output.html]` section of `book.toml`.

This setting replaces straight quotes with typographic quotes, turns ... into an ellipsis, and converts hyphen sequences into proper dashes when building. It improves readability by making punctuation clearer and more natural to scan, especially in longer text.

Using `smart-punctuation` instead of `curly-quotes` follows current mdBook recommendations. The latter is deprecated. The change doesn’t impact code blocks.

Tested with a local build. Renders cleanly.

Fixes #382

See: https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options