### PR TITLE
Fix mdbook linkcheck warnings due to Mathjax blocks at build time

### DIFF
--- a/src/math.md
+++ b/src/math.md
@@ -27,8 +27,10 @@ To try it out:
 
 4. Click the **Cards...** button. You’ll see a preview of how the
    equation will appear when the card is reviewed.
-   \\[\sqrt{x}\\]
 
+    $$
+    \sqrt{x}
+    $$
 Anki’s MathJax support expects content in TeX format. If you’re not
 familiar with TeX formatting, please see [this cheatsheet](https://math.meta.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference).
 Please note that point 1 does not apply in Anki - Anki uses `\(` and

--- a/src/stats.md
+++ b/src/stats.md
@@ -118,7 +118,10 @@ If you don't have a backlog, daily load should be approximately equal to
 your number of due cards.
 
 It is calculated as follows:
-\\[\frac{1}{I_1} + \frac{1}{I_2} + \frac{1}{I_3} + \dots + \frac{1}{I_n}\\]
+
+$$
+\frac{1}{I_1} + \frac{1}{I_2} + \frac{1}{I_3} + \dots + \frac{1}{I_n}
+$$
 
 Here, \\(I_n\\) is the interval of
 the n-th card. If the interval is less than one day, the summation term is 1. This


### PR DESCRIPTION
## Fix mdbook linkcheck warnings due to Mathjax blocks at build time

### Problem

A few Mathjax expressions written with `\[\]` delimiters were being misinterpreted as incomplete reference-style links by `mdbook-linkcheck`. This caused the following error at build/serve time:

```zsh
2025-05-25 17:17:29 [INFO] (mdbook::book): Book building has started
2025-05-25 17:17:29 [INFO] (mdbook::book): Running the html backend
2025-05-25 17:17:29 [INFO] (mdbook::book): Running the linkcheck backend
2025-05-25 17:17:29 [INFO] (mdbook::renderer): Invoking the "linkcheck" renderer
warning: Potential incomplete link
    ┌─ stats.md:145:3
    │
145 │ \\[\frac{1}{I_1} + \frac{1}{I_2} + \frac{1}{I_3} + \dots + \frac{1}{I_n}\\]
    │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Did you forget to define a URL for `\frac{1}{I_1} + \frac{1}{I_2} + \frac{1}{I_3} + \dots + \frac{1}{I_n}\\`?
    │
    = hint: declare the link's URL. For example: `[\frac{1}{I_1} + \frac{1}{I_2} + \frac{1}{I_3} + \dots + \frac{1}{I_n}\\]: http://example.com/`

warning: Potential incomplete link
   ┌─ math.md:40:6
   │
40 │    \\[\sqrt{x}\\]
   │      ^^^^^^^^^^^^ Did you forget to define a URL for `\sqrt{x}\\`?
   │
   = hint: declare the link's URL. For example: `[\sqrt{x}\\]: http://example.com/`
```

These are false positives. The expressions were not links, but properly formatted block math.

### Fix

Replaced the two block-style math expressions causing the warnings by switching `\[\]` with equivalent `$$...$$` delimiters. This:

* Preserves rendering in the generated HTML output
* Prevents `linkcheck` from misinterpreting expressions as broken links
* Requires no change to tooling or build configuration

### Visual sanity check

* Verified that rendered output remains visually correct after `mdbook build` or `mdbook serve`

![CleanShot 2025-05-25 at 17 39 45](https://github.com/user-attachments/assets/22b87197-92dc-4d4e-b890-d298459f3763)

![CleanShot 2025-05-25 at 17 40 05](https://github.com/user-attachments/assets/f80296a6-3766-4bb0-9f2e-df08f8be672d)

* No lintcheck warnings

![CleanShot 2025-05-25 at 17 43 42](https://github.com/user-attachments/assets/897193f6-567c-4b85-8f4f-8e739b227718)

--- 

Edit:
- mdbook version 0.4.50
- mdbook-linkcheck version 0.7.7