### PR TITLE
ADD the version string to stdout in GH actions (build.sh)

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -7,4 +7,5 @@ export PATH="$HOME:$PATH"
 if [ "$CHECK" = "" ]; then
     rm $HOME/mdbook-linkcheck
 fi
+mdbook --version
 mdbook build


### PR DESCRIPTION
This makes it easier to identify version specific problems in the future like the one we faced in https://github.com/ankitects/anki-manual/pull/389#issuecomment-2930623051.

The added command just prints the version and then exits.