### PR TITLE
document searching exact wording of a field

### DIFF
--- a/src/searching.md
+++ b/src/searching.md
@@ -480,3 +480,6 @@ interday learning cards due today.
 
 `prop:resched=0`\
 cards rescheduled today, either using **Set due date** or **Reschedule cards on change**.
+
+`*:dog`
+searches for notes with a field that exactly says "dog".


### PR DESCRIPTION
Added `*:...` searches. I figured it can't put under "limiting to a field" so added to the end.

* Fix https://github.com/ankitects/anki/issues/5454