### PR TITLE
make keyboard shortcuts consistent

### DIFF
--- a/src/editing.md
+++ b/src/editing.md
@@ -239,7 +239,7 @@ is that flags work at [card](getting-started.md#cards) level, so flagging a card
 won't have any effect on the card's siblings.
 
 You can flag / unflag cards directly while in review mode (by pressing
-<kbd>CTRL</kbd> + <kbd>1-7</kbd> on Windows or <kbd>CMD</kbd> + <kbd>1-7</kbd> on Mac)
+<kbd>Ctrl</kbd>+<kbd>1-7</kbd> on Windows or <kbd>Cmd</kbd>+<kbd>1-7</kbd> on Mac)
 and from the [Browser.](browsing.md)
 
 ### The "Marked" Tag

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -5,14 +5,12 @@
 ## Change the Video Driver
 
 ### Changing the Driver From the Preferences Screen
-
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
 changing the video driver in the preferences screen by navigating to **Anki →
 Preferences** and then selecting the driver from the dropdown menu. After that it
 is necessary to restart Anki.
 
 ### Changing the Driver From Terminal.app
-
 Older Anki versions did not provide an option in the preferences, but allowed
 you to adjust the driver by opening Terminal.app, then pasting the following and hit <kbd>Enter</kbd>:
 

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -5,12 +5,14 @@
 ## Change the Video Driver
 
 ### Changing the Driver From the Preferences Screen
+
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
 changing the video driver in the preferences screen by navigating to **Anki →
 Preferences** and then selecting the driver from the dropdown menu. After that it
 is necessary to restart Anki.
 
 ### Changing the Driver From Terminal.app
+
 Older Anki versions did not provide an option in the preferences, but allowed
 you to adjust the driver by opening Terminal.app, then pasting the following and hit <kbd>Enter</kbd>:
 
@@ -25,7 +27,7 @@ remove that file.
 
 ## eGPUs
 
-If you experience blank screens when using an external graphics card on a Mac, you can <kbd>Ctrl</kbd>+click on the Anki app, click **Get Info**, and enable the **prefer eGPU** option.
+If you experience blank screens when using an external graphics card on a Mac, you can <kbd>Ctrl</kbd>-click on the Anki app, click **Get Info**, and enable the **prefer eGPU** option.
 
 ## Monitors with Different Resolutions
 

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -72,6 +72,6 @@ immediately after starting Anki will help.
 ### 8. If the problem remains
 
 If you've confirmed you are using the latest Anki version, and are still
-receiving errors when starting Anki while holding down the shift key,
+receiving errors when starting Anki while holding down the <kbd>Shift</kbd> key,
 please [report the problem](./getting-help.md), including the next error you
 receive in your post.


### PR DESCRIPTION
- capitalize first letter of each key and remove spaces between keys and plus signs (consistent with #416)
- use "Key-click" (common in the manual) instead of "Key+click" (less common)