### PR TITLE
Add note for prop:pos in page Searching

### DIFF
--- a/src/searching.md
+++ b/src/searching.md
@@ -313,6 +313,9 @@ cards that been lapsed more than 3 times.
 `prop:ease!=2.5`\
 cards easier or harder than default ease.
 
+`prop:pos<=100`\
+new cards with a position in the queue less than or equal to 100.
+
 The following searches require Anki 23.10+ and FSRS enabled:
 
 `prop:s>21`\


### PR DESCRIPTION
This PR adds a note for the seemingly undocumented search feature `prop:pos`.

I discovered this feature by browsing Anki's source code, discovering `Position(u32)` in enum `PropertyKind`, and working backward from there.