### PR TITLE
Document flag:0 for no flags in page Searching

### DIFF
--- a/src/searching.md
+++ b/src/searching.md
@@ -264,7 +264,7 @@ cards that are in learning for the first time.
 ## Flags
 
 `flag:0`\
-cards with no flags.
+cards without a flag.
 
 `flag:1`\
 cards with a red flag.


### PR DESCRIPTION
This PR adds a note for the previously undocumented `flag:0` search feature. Searching for `flag:0` pulls up cards with no flags.

I discovered this feature by inputting an invalid `flag:` search (example: `flag:asdasd`) and observing the following error message (emphasis added):

> Invalid search: ⁨flag: must be followed by a valid flag number: 1 (red), 2 (orange), 3 (green), 4 (blue), 5 (pink), 6 (turquoise), 7 (purple) or **0 (no flag)**.⁩