### PR TITLE
Remove duplicate word in cloze explanation

### DIFF
--- a/src/templates/errors.md
+++ b/src/templates/errors.md
@@ -137,7 +137,7 @@ When making clozes, each cloze number is turned into a separate card. For exampl
 {{c1::This}} is a {{c2::sample}} {{c3::sentence}}.
 ```
 
-If you you later edit the text, and either remove or change a cloze number, the previously created card may become blank. For example:
+If you later edit the text, and either remove or change a cloze number, the previously created card may become blank. For example:
 
 ```
 {{c1::This}} is a {{c2::sample}}


### PR DESCRIPTION
Removes duplicate word in https://docs.ankiweb.net/templates/errors.html#single-empty-cards
