### PR TITLE
[SyncServer] Add instructions for credentials

### DIFF
--- a/src/sync-server.md
+++ b/src/sync-server.md
@@ -135,6 +135,7 @@ that the server binds to.
 
 ## Client Setup
 
+### Server URL
 You'll need to determine your computer's network IP address, and then
 point each of your Anki clients to the address, e.g something like
 `http://192.168.1.200:8080/`. The URL can be configured in the preferences.
@@ -148,6 +149,9 @@ Older desktop clients required you to define `SYNC_ENDPOINT` and
 `http://192.168.1.200:8080/sync/` and `http://192.168.1.200:8080/msync/`
 respectively. AnkiDroid clients before 2.16 require separate configuration for
 the two endpoints.
+
+### Credentials
+To be able to synchronize, put your user credential (`SYNC_USER1` for example) in the **AnkiWeb account** section of the preferences.
 
 ## Reverse Proxies
 

--- a/src/sync-server.md
+++ b/src/sync-server.md
@@ -151,7 +151,8 @@ respectively. AnkiDroid clients before 2.16 require separate configuration for
 the two endpoints.
 
 ### Credentials
-To be able to synchronize, put your user credential (`SYNC_USER1` for example) in the **AnkiWeb account** section of the preferences.
+To be able to synchronize, put your user credential (`SYNC_USER1` for example)
+in the **AnkiWeb account** section of the preferences.
 
 ## Reverse Proxies
 


### PR DESCRIPTION
It is **very** hard to understand, when self-hosting your syncserver, where you must put your credentials in order to synchronize the whole thing.

[This forum topic](https://forums.ankiweb.net/t/how-to-use-self-hosted-anki-server-on-linux-and-windows-anki-client/49264) illustrates the case. There's no prompt anywhere asking for the credentials, and it's *not* obvious that the credentials must be set in **AnkiWeb Account**, because it's written everywhere that's it's a different service, which is not affiliated with Anki...

I also struggled for a long time before finally figuring it out.

So anyways, the UI deserves to be enhanced as well.

In this PR,  I added instructions for where to put the user credentials when using a self-hosted syncserver.