### PR TITLE
Add example for nc: with German ß

### DIFF
--- a/src/searching.md
+++ b/src/searching.md
@@ -178,6 +178,9 @@ matches notes with "uber", "über", "Über" and so on.
 `nc:は`\
 matches "は", "ば", and "ぱ".
 
+`nc:heisen`\
+matches notes with "heißen", since ß is treated as s (not ss).
+
 Searches that ignore combining characters are slower than regular searches.
 
 ## Regular expressions

--- a/src/searching.md
+++ b/src/searching.md
@@ -178,8 +178,8 @@ matches notes with "uber", "über", "Über" and so on.
 `nc:は`\
 matches "は", "ば", and "ぱ".
 
-`nc:heisen`\
-matches notes with "heißen", since ß is treated as s (not ss).
+`nc:heisen` or `nc:heißen`\
+matches notes with "heißen" and with "heisen", since ß is treated as s (not ss) and s is treated as ß.
 
 Searches that ignore combining characters are slower than regular searches.
 


### PR DESCRIPTION
This issue felt straightforward and good for me as a beginner. This pull request adds an example to the Searching page, clarifying how nc: treats the German ß. I tried to follow the same structure as the other examples and feel free to leave feedback, I really appreciate it!

Fixes #450
