### PR TITLE
Remove redundant ALT text in studying.md

### DIFF
--- a/src/studying.md
+++ b/src/studying.md
@@ -13,7 +13,7 @@ subdecks it contains.
 On the decks screen, your decks and subdecks will be displayed in a list. [New, Learn, and Due (To Review)](getting-started.md#card-states)
 cards for that day will be also displayed here.
 
-![Decks screen](media/decks_screen.png)
+![](media/decks_screen.png)
 
 When you click on a deck, it will become the "current deck", and Anki
 will change to the study screen. You can return to the deck list at any time by clicking on “Decks” at
@@ -29,13 +29,13 @@ delete the deck, change its [options](deck-options.md), or [export](exporting.md
 After clicking on a deck to study, you’ll see a screen that shows you
 how many cards are due today. This is called the "deck overview" screen:
 
-![Study overview](media/study_overview.png)
+![](media/study_overview.png)
 
 The cards are split into [three types](getting-started.md#card-states): New, Learning, and To Review.
 If you have [Bury siblings](#siblings-and-burying) activated in your deck options, you
 may see how many cards will be buried in grey:
 
-![Study overview (Buried Cards)](media/study_overview_buried_cards.png)
+![](media/study_overview_buried_cards.png)
 
 To start a study session, click the **Study Now** button. Anki will
 proceed to show you cards until the cards to be shown for the day have


### PR DESCRIPTION
Removed redundant ALT text in studying.md as described in issue. Fixes #425.
