### PR TITLE
docs: update anki-consol.exe

### DIFF
--- a/src/platform/windows/startup-issues.md
+++ b/src/platform/windows/startup-issues.md
@@ -74,8 +74,16 @@ Starting Anki from a terminal may reveal a bit more information about some
 errors. After installing the latest Anki version and ensuring all Windows
 updates are installed, instead of running Anki directly, press the <kbd>Windows</kbd> key (or open the Start menu), type `cmd`, and launch Command Prompt. When the terminal window opens, paste the following command, and press <kbd>Enter</kbd>. (The path will be different if Anki is installed in a location that is not the default.)
 
+For Anki 25.07 and later:
+
 ```
 %LocalAppData%\Programs\Anki\anki-console.exe
+```
+
+For Anki versions before 25.07:
+
+```
+%LocalAppData%\Programs\Anki\anki-console.bat
 ```
 
 Presumably Anki will fail to open like before, but the output in the terminal window may reveal something about

--- a/src/platform/windows/startup-issues.md
+++ b/src/platform/windows/startup-issues.md
@@ -74,13 +74,13 @@ Starting Anki from a terminal may reveal a bit more information about some
 errors. After installing the latest Anki version and ensuring all Windows
 updates are installed, instead of running Anki directly, press the <kbd>Windows</kbd> key (or open the Start menu), type `cmd`, and launch Command Prompt. When the terminal window opens, paste the following command, and press <kbd>Enter</kbd>. (The path will be different if Anki is installed in a location that is not the default.)
 
-For Anki 25.07 and later:
+_For Anki 25.07 and later, paste_
 
 ```
 %LocalAppData%\Programs\Anki\anki-console.exe
 ```
 
-For Anki versions before 25.07:
+_For Anki versions before 25.07, paste_
 
 ```
 %LocalAppData%\Programs\Anki\anki-console.bat

--- a/src/platform/windows/startup-issues.md
+++ b/src/platform/windows/startup-issues.md
@@ -75,7 +75,7 @@ errors. After installing the latest Anki version and ensuring all Windows
 updates are installed, instead of running Anki directly, press the <kbd>Windows</kbd> key (or open the Start menu), type `cmd`, and launch Command Prompt. When the terminal window opens, paste the following command, and press <kbd>Enter</kbd>. (The path will be different if Anki is installed in a location that is not the default.)
 
 ```
-%LocalAppData%\Programs\Anki\anki-console.bat
+%LocalAppData%\Programs\Anki\anki-console.exe
 ```
 
 Presumably Anki will fail to open like before, but the output in the terminal window may reveal something about

--- a/src/platform/windows/startup-issues.md
+++ b/src/platform/windows/startup-issues.md
@@ -74,7 +74,7 @@ Starting Anki from a terminal may reveal a bit more information about some
 errors. After installing the latest Anki version and ensuring all Windows
 updates are installed, instead of running Anki directly, press the <kbd>Windows</kbd> key (or open the Start menu), type `cmd`, and launch Command Prompt. When the terminal window opens, paste the following command, and press <kbd>Enter</kbd>. (The path will be different if Anki is installed in a location that is not the default.)
 
-_For Anki 25.07 and later, paste_
+For Anki 25.07 and later, paste
 
 ```
 %LocalAppData%\Programs\Anki\anki-console.exe

--- a/src/platform/windows/startup-issues.md
+++ b/src/platform/windows/startup-issues.md
@@ -80,7 +80,7 @@ For Anki 25.07 and later, paste
 %LocalAppData%\Programs\Anki\anki-console.exe
 ```
 
-_For Anki versions before 25.07, paste_
+For Anki versions before 25.07, paste
 
 ```
 %LocalAppData%\Programs\Anki\anki-console.bat


### PR DESCRIPTION
This PR updates the [Startup Issues](https://docs.ankiweb.net/platform/windows/startup-issues.html) and [Console Output](https://addon-docs.ankiweb.net/console-output.html#windows) documentation to reflect changes introduced in Anki 25.07 and later. So the changes replaced references to `anki-console.bat` with `anki-console.exe`. 

Link for the PR for [addon-docs PR](https://github.com/ankitects/addon-docs/pull/29).

Fixes #435 