### PR TITLE
docs: update styling.md on how to display code snippets

### DIFF
--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -231,10 +231,9 @@ the [editing](../editing.md#customizing-fields) section.
 
 ## Displaying Code Snippets
 
-If you want to include code in your Anki cards, you can use HTML tags to format text as code. To enter HTML mode:
-
-- On Windows, press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>
-- On a Mac, press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>
+If you want to include code in your Anki cards, you can use HTML tags to format
+text as code. For that, you need to open the
+[HTML view](../editing.md#editing-features).
 
 ### Inline code
 

--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -236,14 +236,16 @@ If you want to include code in your Anki cards, you can use HTML tags to format 
 - On Windows, press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>
 - On a Mac, press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>
 
-**Inline code**\
+### Inline code
+
 Wrap your text with the `<code>` tag:
 
 ```html
 <code>console.log("Hello World!");</code>
 ```
 
-**Code blocks**\
+### Code blocks
+
 Use `<pre><code>` for multi-line code:
 
 ```html

--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -229,6 +229,31 @@ of only certain fields by wrapping their references in some HTML:
 To change the direction of fields in the editor, please see
 the [editing](../editing.md#customizing-fields) section.
 
+## Displaying Code Snippets
+
+If you want to include code in your Anki cards, you can use HTML tags to format text as code. To enter HTML mode:
+
+- On Windows, press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>
+- On a Mac, press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>
+
+**Inline code**\
+Wrap your text with the `<code>` tag:
+
+```html
+<code>console.log("Hello World!");</code>
+```
+
+**Code blocks**\
+Use `<pre><code>` for multi-line code:
+
+```html
+<pre><code>
+function square(number) {
+  return number * number;
+};
+</code></pre>
+```
+
 ## Other HTML
 
 Your templates can contain arbitrary HTML, which means that all the


### PR DESCRIPTION
This PR adds documentation on how to format code snippets in Anki cards. The new section covers keyboard shortcuts for entering HTML mode and provides examples for both inline code and code blocks. This will help users, especially those in IT/engineering fields, properly display code in their flashcards.

Closes https://github.com/ankitects/anki-manual/issues/456
