### PR TITLE
Add new cloze multi-card syntax documentation

### DIFF
--- a/src/editing.md
+++ b/src/editing.md
@@ -430,6 +430,19 @@ sure to clone the existing Cloze type instead of another type of note.
 Things like formatting can be customized, but it is not possible to add
 extra card templates to the cloze note type.
 
+Anki now supports a new syntax that allows a single cloze deletion to appear on multiple cards:
+
+    {{c1::-té}}, {{c2::-sion}}, or {{c3::-tion}} are {{c1,2,3,4::feminine}}.
+
+This creates 4 cards, each hiding “feminine” in a different context.
+The same result can however still be achieved with the older nested syntax:
+
+    {{c1::-té}}, {{c2::-sion}}, {{c3::-tion}} are {{c4::{{c3::{{c2::{{c1::feminine}}}}}}}}
+
+The new syntax is easier to read and write, while the old syntax is more verbose.
+
+*Note: The new multi-card syntax is only available in the latest Anki version (currently beta, but will be included in the next release).*
+
 ## Image Occlusion
 
 Anki 23.10+ supports Image Occlusion cards natively. An Image
@@ -533,7 +546,7 @@ Mac:
 - <http://www.macworld.com/article/1147039/os-x/accentinput.html>
   
 Linux:
-- Gnome: <https://help.gnome.org/users/gnome-help/stable/tips-specialchars.html.en>
+- Gnome: <https://help.gnome.org//gnome-help/tips-specialchars.html>
 - KDE Plasma: <https://userbase.kde.org/Tutorials/ComposeKey>
 
 ### Adding keyboard layouts for specific languages

--- a/src/editing.md
+++ b/src/editing.md
@@ -430,7 +430,8 @@ sure to clone the existing Cloze type instead of another type of note.
 Things like formatting can be customized, but it is not possible to add
 extra card templates to the cloze note type.
 
-Anki now supports a new syntax that allows a single cloze deletion to appear on multiple cards:
+Anki now supports a new syntax that allows a single cloze deletion to appear on 
+multiple cards:
 
     {{c1::-té}}, {{c2::-sion}}, or {{c3::-tion}} are {{c1,2,3,4::feminine}}.
 
@@ -439,9 +440,8 @@ The same result can however still be achieved with the older nested syntax:
 
     {{c1::-té}}, {{c2::-sion}}, {{c3::-tion}} are {{c4::{{c3::{{c2::{{c1::feminine}}}}}}}}
 
-The new syntax is easier to read and write, while the old syntax is more verbose.
-
-*Note: The new multi-card syntax is only available in the latest Anki version (currently beta, but will be included in the next release).*
+The new syntax is easier to read and write, while the old syntax is more 
+verbose.
 
 ## Image Occlusion
 
@@ -546,7 +546,7 @@ Mac:
 - <http://www.macworld.com/article/1147039/os-x/accentinput.html>
   
 Linux:
-- Gnome: <https://help.gnome.org//gnome-help/tips-specialchars.html>
+- Gnome: <https://help.gnome.org/gnome-help/tips-specialchars.html>
 - KDE Plasma: <https://userbase.kde.org/Tutorials/ComposeKey>
 
 ### Adding keyboard layouts for specific languages


### PR DESCRIPTION
Updated the Cloze section to document the new multi-card cloze deletion syntax, showing the simpler syntax alongside the older nested version. Corrected the Gnome keyboard layout link, which previously pointed to a non-functional URL.