### PR TITLE
Docs: Update installation documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,10 @@ In order to use mdBook, please first ensure that you have [Rust](https://www.rus
 
 Next, install mdBook and its pre-processors
 ```
-cargo install mdbook
-cargo install mdbook-toc
-cargo install mdbook-linkcheck
+cargo install mdbook --version 0.4.52
+cargo install mdbook-toc --version 0.14.2 --force
+cargo install mdbook-admonish --version 1.20.0 --force
+cargo install mdbook-linkcheck --version 0.7.7 --force
 ```
 
 ### Develop and preview


### PR DESCRIPTION
In relation to [issue 478](https://github.com/ankitects/anki/issues/5426), I have updated the instructions to include the correct versions which enable users to correctly open mdBook:

cargo install mdbook --version 0.4.52
cargo install mdbook-toc --version 0.14.2 --force
cargo install mdbook-admonish --version 1.20.0 --force
cargo install mdbook-linkcheck --version 0.7.7 --force