### PR TITLE
List live Persian (فارسی) translation of the manual

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -31,7 +31,7 @@ translations may not always be up to date.
 - [русский язык](https://andreykaiu.github.io/anki-manual-ru/)
 - [Українська](https://astropsy999.github.io/anki-manual/)
 - [العربية](https://abdnh.github.io/anki-manual/)
-- [فارسى](https://web.archive.org/web/20250328102629/http://ankidroid.ir/anki.pdf)
+- [فارسى](https://msadrashakouri.github.io/anki-manual/)
 - [日本語](http://wikiwiki.jp/rage2050/)
 - [简体中文](https://open-spaced-repetition.github.io/anki-manual-zh-CN/)
 


### PR DESCRIPTION
Hi! I've completed a Persian translation of the manual and would like it listed on the translations section of the introduction page.

- Live site: https://msadrashakouri.github.io/anki-manual/
- Source: https://github.com/MSadraShakouri/anki-manual (a fork, CC BY-SA 4.0, same as upstream)
- All 57 sections translated, full RTL layout (Vazirmatn font, mirrored UI), Persian-normalized search
- Kept up to date with a daily workflow that tracks upstream commits

The current فارسى entry points to an archived copy of a long-abandoned PDF translation; this PR replaces it with the live site.

Per the translation docs ("After translating at least one file, please get in touch") — this PR is that hello. Happy to adjust anything if needed!